### PR TITLE
[🔧 Chore/#10] TypeScript 타입 체크를 위한 TSC 워크플로우 추가

### DIFF
--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -1,0 +1,41 @@
+# .github/workflows/tsc.yml
+name: TypeScript Check (tsc)
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  tsc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Next.js typegen
+        run: pnpm typegen
+
+      - name: Run TypeScript
+        run: pnpm exec tsc --noEmit

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -38,4 +38,4 @@ jobs:
         run: pnpm typegen
 
       - name: Run TypeScript
-        run: pnpm exec tsc --noEmit
+        run: pnpm type-check

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
+    "typegen": "next typegen",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
     "format": "prettier --write src",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "typegen": "next typegen",
+    "type-check": "tsc --noEmit",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
     "format": "prettier --write src",


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #10 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- GitHub Actions에 TypeScript 타입 체크 워크플로우 추가 (`.github/workflows/tsc.yml`)
- `main`, `dev` 브랜치 대상 PR 및 push 시 TypeScript 타입 체크 자동 실행
- `pnpm exec tsc --noEmit`으로 타입 에러만 검증하고 빌드 결과물은 생성하지 않도록 설정

주요 옵션:

- `actions/setup-node@v4`: Node.js 20 환경을 설정합니다.
- `pnpm install --frozen-lockfile`: lockfile과 실제 의존성 정보가 다르면 실패시켜, CI에서 항상 동일한 버전의 패키지를 설치합니다.
- `pnpm exec tsc --noEmit`: 프로젝트에 설치된 TypeScript 컴파일러로 타입 검사만 수행하고 출력 파일은 생성하지 않습니다.


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
