### PR TITLE
[✨ Feat/#40] 프로필(아바타+닉네임) 컴포넌트 구현

### DIFF
--- a/src/shared/ui/avatar/Avatar.tsx
+++ b/src/shared/ui/avatar/Avatar.tsx
@@ -9,9 +9,10 @@ import { cn } from '@/shared/utils/cn';
  * 사용자의 프로필 이미지를 표시하는 아바타 컴포넌트입니다.
  * 이미지 로드 실패 시 또는 이미지가 없을 때 Fallback UI를 제공합니다.
  *
- * @example
+ * @example Avatar 내부에서 알아서 처리하게끔 분기없이 작성
  * <Avatar user={user}>
- *  {user.profileImageUrl ? <Avatar.Img /> : <Avatar.Fallback />}
+ *  <Avatar.Img />
+ *  <Avatar.Fallback />
  * </Avatar>
  */
 export default function Avatar({ children, user, size = 'lg', className, loading }: AvatarProps) {

--- a/src/shared/ui/profile/Profile.stories.tsx
+++ b/src/shared/ui/profile/Profile.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import Profile from '@/shared/ui/profile/Profile';
+
+const meta: Meta<typeof Profile> = {
+  title: 'Shared/Profile',
+  component: Profile,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    nicknameClassName: {
+      control: 'select',
+      options: ['text-gray-500', 'text-gray-950', 'text-white'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    user: {
+      nickname: '정만철',
+      profileImageUrl:
+        'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSgGVm5P0-8Mjkm597XaYeSL2BlMIwp-APf0Q&s',
+    },
+    size: 'sm',
+  },
+};

--- a/src/shared/ui/profile/Profile.tsx
+++ b/src/shared/ui/profile/Profile.tsx
@@ -1,0 +1,41 @@
+import Avatar from '@/shared/ui/avatar/Avatar';
+import type { AvatarProps } from '@/shared/ui/avatar/types';
+import { cn } from '@/shared/utils/cn';
+
+type ProfileProps = AvatarProps & {
+  nicknameClassName?: string;
+};
+
+/**
+ * 아바타 + 닉네임 조합으로 된 프로필 컴포넌트입니다.
+ * 닉네임 색상은 검정(text-gray-950)이 기본 값입니다.
+ *
+ * @example
+ * // 기본 컴포넌트
+ * <Profile user={user} size="md" />
+ *
+ * // 색상 변경 컴포넌트
+ * <Profile user={user} size="md" nicknameClassName="text-gray-500" />
+ * <Profile user={user} size="md" nicknameClassName="text-white" />
+ *
+ */
+export default function Profile({
+  user,
+  size = 'sm',
+  nicknameClassName = 'text-gray-950',
+}: ProfileProps) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <Avatar user={user} size={size}>
+        <Avatar.Img />
+        <Avatar.Fallback />
+      </Avatar>
+      <span
+        className={cn('typo-14-medium', nicknameClassName)}
+        aria-label={`${user?.nickname || '사용자'}`}
+      >
+        {user.nickname ?? '사용자'}
+      </span>
+    </div>
+  );
+}

--- a/src/shared/ui/profile/Profile.tsx
+++ b/src/shared/ui/profile/Profile.tsx
@@ -30,12 +30,7 @@ export default function Profile({
         <Avatar.Img />
         <Avatar.Fallback />
       </Avatar>
-      <span
-        className={cn('typo-14-medium', nicknameClassName)}
-        aria-label={`${user?.nickname || '사용자'}`}
-      >
-        {user.nickname ?? '사용자'}
-      </span>
+      <span className={cn('typo-14-medium', nicknameClassName)}>{user?.nickname ?? '사용자'}</span>
     </div>
   );
 }

--- a/src/shared/ui/profile/Profile.tsx
+++ b/src/shared/ui/profile/Profile.tsx
@@ -2,7 +2,7 @@ import Avatar from '@/shared/ui/avatar/Avatar';
 import type { AvatarProps } from '@/shared/ui/avatar/types';
 import { cn } from '@/shared/utils/cn';
 
-type ProfileProps = AvatarProps & {
+type ProfileProps = Omit<AvatarProps, 'children'> & {
   nicknameClassName?: string;
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #40

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

📌 작업 내용
헤더에 사용되는 아바타 + 닉네임 조합으로 된 프로필 컴포넌트 구현했습니다.

🧱 컴포넌트 구조
```
// 기본 컴포넌트
 <Profile user={user} size="md" />
```

💡확인 사항
- 헤더에 사용되는 컴포넌트라서 서정님 작업하시고 폴더 이동해주시면 됩니다 :)

### 스크린샷 (선택)
<img width="120" height="61" alt="스크린샷 2026-04-23 15 51 07" src="https://github.com/user-attachments/assets/baa24cbc-88cf-4dcf-804a-89644d995da2" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
