### PR TITLE
[✨ Feat/#54] 리뷰(별, 평점, 리뷰 수) 컴포넌트 생성

### DIFF
--- a/src/shared/ui/rating-summary/RatingSummary.stories.tsx
+++ b/src/shared/ui/rating-summary/RatingSummary.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import RatingSummary from '@/shared/ui/rating-summary/RatingSummary';
+
+const meta: Meta<typeof RatingSummary> = {
+  title: 'Shared/RatingSummary',
+  component: RatingSummary,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof RatingSummary>;
+
+// 가격/인
+export const PriceBase: Story = {
+  render: (args) => <RatingSummary {...args} />,
+  args: {
+    averageRating: 4.2,
+    totalCount: 672,
+  },
+};

--- a/src/shared/ui/rating-summary/RatingSummary.stories.tsx
+++ b/src/shared/ui/rating-summary/RatingSummary.stories.tsx
@@ -10,8 +10,7 @@ const meta: Meta<typeof RatingSummary> = {
 export default meta;
 type Story = StoryObj<typeof RatingSummary>;
 
-// 가격/인
-export const PriceBase: Story = {
+export const Rating: Story = {
   render: (args) => <RatingSummary {...args} />,
   args: {
     averageRating: 4.2,

--- a/src/shared/ui/rating-summary/RatingSummary.stories.tsx
+++ b/src/shared/ui/rating-summary/RatingSummary.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof RatingSummary> = {
 export default meta;
 type Story = StoryObj<typeof RatingSummary>;
 
-export const Rating: Story = {
+export const RatingUi: Story = {
   render: (args) => <RatingSummary {...args} />,
   args: {
     averageRating: 4.2,

--- a/src/shared/ui/rating-summary/RatingSummary.tsx
+++ b/src/shared/ui/rating-summary/RatingSummary.tsx
@@ -1,0 +1,45 @@
+import { StarIcon } from '@/shared/assets/icons';
+import { cn } from '@/shared/utils/cn';
+
+/**
+ * 별점 평균과 리뷰 수를 함께 표시하는 컴포넌트입니다.
+ *
+ * @example
+ * // 기본
+ * <RatingSummary averageRating={4.5} totalCount={128} />
+ *
+ * // 텍스트 스타일 변경
+ * <RatingSummary
+ *   averageRating={4.5}
+ *   totalCount={128}
+ *   ratingClassName="text-gray-950"
+ *   countClassName="text-gray-400"
+ *  />
+ */
+export type RatingSummaryProps = {
+  averageRating: number;
+  totalCount: number;
+  /** 평균 별점 텍스트에 적용할 스타일 */
+  ratingClassName?: string;
+  /** 리뷰 수 텍스트에 적용할 스타일 */
+  countClassName?: string;
+};
+
+export default function RatingSummary({
+  averageRating,
+  totalCount,
+  ratingClassName,
+  countClassName,
+}: RatingSummaryProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <StarIcon className="h-5 w-5 -translate-y-px" />
+      <div className="flex items-center gap-0.5 leading-none">
+        <span className={cn('typo-14-medium text-gray-700', ratingClassName)}>
+          {averageRating.toFixed(1)}
+        </span>
+        <span className={cn('typo-14-medium text-gray-700', countClassName)}>({totalCount})</span>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/rating-summary/RatingSummary.tsx
+++ b/src/shared/ui/rating-summary/RatingSummary.tsx
@@ -32,17 +32,16 @@ export default function RatingSummary({
   countClassName,
 }: RatingSummaryProps) {
   const safeRating = Math.min(5, Math.max(0, averageRating));
+  const ratingText = safeRating.toFixed(1);
 
   return (
     <div
       className="flex items-center gap-1"
-      aria-label={`별점 ${averageRating}점, 리뷰 ${totalCount}개`}
+      aria-label={`별점 ${ratingText}점, 리뷰 ${totalCount}개`}
     >
       <StarIcon className="h-5 w-5 -translate-y-px" aria-hidden="true" />
       <div className="flex items-center gap-0.5 leading-none">
-        <span className={cn('typo-14-medium text-gray-700', ratingClassName)}>
-          {safeRating.toFixed(1)}
-        </span>
+        <span className={cn('typo-14-medium text-gray-700', ratingClassName)}>{ratingText}</span>
         <span className={cn('typo-14-medium text-gray-700', countClassName)}>
           ({totalCount.toLocaleString()})
         </span>

--- a/src/shared/ui/rating-summary/RatingSummary.tsx
+++ b/src/shared/ui/rating-summary/RatingSummary.tsx
@@ -32,8 +32,11 @@ export default function RatingSummary({
   countClassName,
 }: RatingSummaryProps) {
   return (
-    <div className="flex items-center gap-1">
-      <StarIcon className="h-5 w-5 -translate-y-px" />
+    <div
+      className="flex items-center gap-1"
+      aria-label={`별점 ${averageRating}점, 리뷰 ${totalCount}개`}
+    >
+      <StarIcon className="h-5 w-5 -translate-y-px" aria-hidden />
       <div className="flex items-center gap-0.5 leading-none">
         <span className={cn('typo-14-medium text-gray-700', ratingClassName)}>
           {averageRating.toFixed(1)}

--- a/src/shared/ui/rating-summary/RatingSummary.tsx
+++ b/src/shared/ui/rating-summary/RatingSummary.tsx
@@ -31,15 +31,17 @@ export default function RatingSummary({
   ratingClassName,
   countClassName,
 }: RatingSummaryProps) {
+  const safeRating = Math.min(5, Math.max(0, averageRating));
+
   return (
     <div
       className="flex items-center gap-1"
       aria-label={`별점 ${averageRating}점, 리뷰 ${totalCount}개`}
     >
-      <StarIcon className="h-5 w-5 -translate-y-px" aria-hidden />
+      <StarIcon className="h-5 w-5 -translate-y-px" aria-hidden="true" />
       <div className="flex items-center gap-0.5 leading-none">
         <span className={cn('typo-14-medium text-gray-700', ratingClassName)}>
-          {averageRating.toFixed(1)}
+          {safeRating.toFixed(1)}
         </span>
         <span className={cn('typo-14-medium text-gray-700', countClassName)}>
           ({totalCount.toLocaleString()})

--- a/src/shared/ui/rating-summary/RatingSummary.tsx
+++ b/src/shared/ui/rating-summary/RatingSummary.tsx
@@ -41,7 +41,9 @@ export default function RatingSummary({
         <span className={cn('typo-14-medium text-gray-700', ratingClassName)}>
           {averageRating.toFixed(1)}
         </span>
-        <span className={cn('typo-14-medium text-gray-700', countClassName)}>({totalCount})</span>
+        <span className={cn('typo-14-medium text-gray-700', countClassName)}>
+          ({totalCount.toLocaleString()})
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #54

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 체험 카드와 체험 상세 페이지에 사용되는 평균 별점과 리뷰 수를 표시하는 컴포넌트 구현
- ratingClassName, countClassName props로 텍스트 스타일 외부 제어 가능

### 스크린샷 (선택)
<img width="401" height="153" alt="스크린샷 2026-04-23 23 49 13" src="https://github.com/user-attachments/assets/4219a814-9ed8-495d-96a7-2a9bc659dc2e" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
