### PR TITLE
[✨ Feat/#58] ActionDropdown 구현

### DIFF
--- a/src/shared/types/common.ts
+++ b/src/shared/types/common.ts
@@ -14,6 +14,6 @@ import type { ReactNode } from 'react';
  * }
  * ```
  */
-export interface WithChildren {
+export type WithChildren = {
   children: ReactNode;
-}
+};

--- a/src/shared/ui/dropdown/action/ActionDropdown.stories.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdown.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { fn } from 'storybook/test';
+import { MenuIcon } from '@/shared/assets/icons';
+import type { AvatarUser } from '@/shared/ui/avatar/types';
+import {
+  ActionDropdown,
+  ActionDropdownTrigger,
+  ActionDropdownContent,
+  ActionDropdownItem,
+} from '@/shared/ui/dropdown/action';
+import Profile from '@/shared/ui/profile/Profile';
+
+/**
+ * ActionDropdown 컴포넌트 스토리 가이드
+ *
+ * ### 주요 특징
+ * - ActionDropdown은 클릭 시 액션 메뉴를 표시하는 **메뉴형 드롭다운**입니다.
+ * - Trigger / Content / Item으로 구성된 **컴파운드 패턴**을 사용합니다.
+ * - SelectDropdown과 동일한 DropdownBase 인프라를 사용하지만,
+ *   **선택 값이 아닌 즉시 실행 액션**을 목적으로 합니다.
+ *
+ * ### **접근성 규칙**
+ * - Trigger는 `button` 요소이며 `aria-haspopup="menu"`를 가집니다.
+ * - 메뉴의 열림 상태는 `aria-expanded`로 전달됩니다.
+ * - 메뉴 컨테이너는 `role="menu"`,
+ *   각 아이템은 `role="menuitem"`을 사용합니다.
+ * - Trigger 내부에 아이콘만 존재하는 경우,
+ *   `aria-label`을 통해 의미 있는 레이블을 제공합니다.
+ *
+ * ### 사용 예시
+ * ```tsx
+ * <ActionDropdown>
+ *   <ActionDropdownTrigger aria-label="유저 메뉴 열기">
+ *     <Avatar />
+ *   </ActionDropdownTrigger>
+ *   <ActionDropdownContent>
+ *     <ActionDropdownItem onClick={logout}>로그아웃</ActionDropdownItem>
+ *     <ActionDropdownItem onClick={goMyPage}>마이페이지</ActionDropdownItem>
+ *   </ActionDropdownContent>
+ * </ActionDropdown>
+ * ```
+ */
+const meta: Meta<typeof ActionDropdown> = {
+  title: 'Shared/Dropdown/ActionDropdown',
+  component: ActionDropdown,
+  argTypes: {
+    children: {
+      description:
+        '`ActionDropdownTrigger`, `ActionDropdownContent`, `ActionDropdownItem`을 조합하여 전달',
+      table: {
+        type: {
+          summary: 'ReactNode',
+        },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActionDropdown>;
+
+/**
+ * 테스트용 유저 데이터
+ */
+const DEFAULT_USER: AvatarUser = {
+  nickname: '유저',
+  profileImageUrl: null,
+};
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+기본적인 ActionDropdown 예제입니다.
+- 메뉴 아이템 클릭 시 드롭다운이 닫힌 후 액션이 실행됩니다.
+        `,
+      },
+    },
+  },
+  render: () => {
+    return (
+      <div className="h-90">
+        <ActionDropdown>
+          <ActionDropdownTrigger className="flex items-center gap-10" aria-label="유저 메뉴 열기">
+            <Profile user={DEFAULT_USER} />
+          </ActionDropdownTrigger>
+
+          <ActionDropdownContent>
+            <ActionDropdownItem onClick={fn()}>로그아웃</ActionDropdownItem>
+            <ActionDropdownItem onClick={fn()}>마이페이지</ActionDropdownItem>
+          </ActionDropdownContent>
+        </ActionDropdown>
+      </div>
+    );
+  },
+};
+
+export const IconOnlyTrigger: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+아이콘만 사용하는 ActionDropdown 트리거 예제입니다.
+
+- Trigger 내부에 텍스트가 없는 경우,
+  반드시 \`aria-label\`을 제공해야 합니다.
+- 시각적으로는 아이콘만 보이지만,
+  스크린 리더 사용자에게는 명확한 의미가 전달됩니다.
+        `,
+      },
+    },
+  },
+  render: () => {
+    return (
+      <div className="h-90">
+        <ActionDropdown>
+          <ActionDropdownTrigger aria-label="유저 메뉴 열기">
+            <MenuIcon aria-hidden className="h-6 w-6" />
+          </ActionDropdownTrigger>
+
+          <ActionDropdownContent className="-left-20">
+            <ActionDropdownItem onClick={fn()}>로그아웃</ActionDropdownItem>
+            <ActionDropdownItem onClick={fn()}>마이페이지</ActionDropdownItem>
+          </ActionDropdownContent>
+        </ActionDropdown>
+      </div>
+    );
+  },
+};

--- a/src/shared/ui/dropdown/action/ActionDropdown.stories.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdown.stories.tsx
@@ -30,7 +30,7 @@ import Profile from '@/shared/ui/profile/Profile';
  * ### 사용 예시
  * ```tsx
  * <ActionDropdown>
- *   <ActionDropdownTrigger aria-label="유저 메뉴 열기">
+ *   <ActionDropdownTrigger ariaLabel="유저 메뉴 열기">
  *     <Avatar />
  *   </ActionDropdownTrigger>
  *   <ActionDropdownContent>
@@ -82,7 +82,7 @@ export const Default: Story = {
     return (
       <div className="h-90">
         <ActionDropdown>
-          <ActionDropdownTrigger className="flex items-center gap-10" aria-label="유저 메뉴 열기">
+          <ActionDropdownTrigger className="flex items-center gap-10" ariaLabel="유저 메뉴 열기">
             <Profile user={DEFAULT_USER} />
           </ActionDropdownTrigger>
 
@@ -115,7 +115,7 @@ export const IconOnlyTrigger: Story = {
     return (
       <div className="h-90">
         <ActionDropdown>
-          <ActionDropdownTrigger aria-label="유저 메뉴 열기">
+          <ActionDropdownTrigger ariaLabel="유저 메뉴 열기">
             <MenuIcon aria-hidden className="h-6 w-6" />
           </ActionDropdownTrigger>
 

--- a/src/shared/ui/dropdown/action/ActionDropdown.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdown.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { WithChildren } from '@/shared/types/common';
+import BaseDropdownRoot from '@/shared/ui/dropdown/base/BaseDropdown';
+import BaseDropdownProvider from '@/shared/ui/dropdown/base/BaseDropdownProvider';
+
+/**
+ * ## ActionDropdown
+ *
+ * ActionDropdown의 루트 컴포넌트입니다.
+ *
+ * - `BaseDropdownProvider`로 드롭다운의 open 상태를 관리합니다.
+ * - `BaseDropdown`을 기준 요소로 사용해 외부 클릭 시 드롭다운을 닫습니다.
+ * - 메뉴(콘텐츠) 영역은 `w-fit`을 사용해 내용 크기에 맞게 렌더링됩니다.
+ *
+ * @param children - `ActionDropdownTrigger`, `ActionDropdownContent`, `ActionDropdownItem` 조합
+ *
+ * @example
+ * ```tsx
+ * <ActionDropdown>
+ *   <ActionDropdownTrigger>트리거</ActionDropdownTrigger>
+ *   <ActionDropdownContent>
+ *     <ActionDropdownItem onClick={handleEdit}>수정</ActionDropdownItem>
+ *     <ActionDropdownItem onClick={handleDelete}>삭제</ActionDropdownItem>
+ *   </ActionDropdownContent>
+ * </ActionDropdown>
+ * ```
+ */
+
+export default function ActionDropdown({ children }: WithChildren) {
+  return (
+    <BaseDropdownProvider>
+      <BaseDropdownRoot>{children}</BaseDropdownRoot>
+    </BaseDropdownProvider>
+  );
+}

--- a/src/shared/ui/dropdown/action/ActionDropdown.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdown.tsx
@@ -5,7 +5,7 @@ import BaseDropdownRoot from '@/shared/ui/dropdown/base/BaseDropdown';
 import BaseDropdownProvider from '@/shared/ui/dropdown/base/BaseDropdownProvider';
 
 /**
- * ## ActionDropdown
+ * ActionDropdown
  *
  * ActionDropdown의 루트 컴포넌트입니다.
  *
@@ -26,7 +26,6 @@ import BaseDropdownProvider from '@/shared/ui/dropdown/base/BaseDropdownProvider
  * </ActionDropdown>
  * ```
  */
-
 export default function ActionDropdown({ children }: WithChildren) {
   return (
     <BaseDropdownProvider>

--- a/src/shared/ui/dropdown/action/ActionDropdownContent.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdownContent.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { WithChildren } from '@/shared/types/common';
+import useDropdownBaseContext from '@/shared/ui/dropdown/hooks/useDropdownBaseContext';
+import {
+  dropdownListBase,
+  dropdownListShadowStyle,
+} from '@/shared/ui/dropdown/styles/dropdownContent';
+import { cn } from '@/shared/utils/cn';
+
+type ActionDropdownContentProps = WithChildren & {
+  /** 추가로 적용할 스타일 (position 조절에 활용) */
+  className?: string;
+};
+
+/**
+ * ActionDropdownContent
+ *
+ * @description
+ * ActionDropdown의 메뉴 콘텐츠 영역을 담당하는 컴포넌트입니다.
+ *
+ * - 드롭다운이 열린 상태(`isOpen === true`)일 때만 렌더링됩니다.
+ * - 내부에는 `ActionDropdownItem`을 자식으로 배치합니다.
+ *
+ * @example
+ * ```tsx
+ * <ActionDropdownContent>
+ *   <ActionDropdownItem onClick={handleEdit}>수정하기</ActionDropdownItem>
+ *   <ActionDropdownItem onClick={handleDelete}>삭제하기</ActionDropdownItem>
+ * </ActionDropdownContent>
+ * ```
+ */
+export default function ActionDropdownContent({ children, className }: ActionDropdownContentProps) {
+  const { isOpen } = useDropdownBaseContext();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div role="menu" className={cn(dropdownListBase, dropdownListShadowStyle, className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/shared/ui/dropdown/action/ActionDropdownItem.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdownItem.tsx
@@ -43,7 +43,7 @@ export default function ActionDropdownItem({
     onClick();
   };
 
-  //TODO: 키보드 접근성 개선
+  // TODO: 키보드 접근성 개선
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     const key = e.key;
 

--- a/src/shared/ui/dropdown/action/ActionDropdownItem.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdownItem.tsx
@@ -39,8 +39,8 @@ export default function ActionDropdownItem({
   const { setIsOpen } = useDropdownBaseContext();
 
   const executeAction = () => {
-    setIsOpen(false);
     onClick();
+    setIsOpen(false);
   };
 
   // TODO: 키보드 접근성 개선

--- a/src/shared/ui/dropdown/action/ActionDropdownItem.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdownItem.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { KeyboardEvent } from 'react';
+import { WithChildren } from '@/shared/types/common';
+import useDropdownBaseContext from '@/shared/ui/dropdown/hooks/useDropdownBaseContext';
+import {
+  dropdownItemBase,
+  dropdownItemHoverBase,
+  dropdownItemShadowStyle,
+} from '@/shared/ui/dropdown/styles/dropdownItem';
+import { cn } from '@/shared/utils/cn';
+
+type ActionDropdownItemProps = WithChildren & {
+  /** 메뉴 선택 시 실행될 콜백 함수 */
+  onClick: () => void;
+  /** 추가로 적용할 스타일 (width 세부 조절 필요 시) */
+  className?: string;
+};
+
+/**
+ * ActionDropdownItem
+ *
+ * @description
+ * ActionDropdown에서 사용되는 개별 메뉴 아이템 컴포넌트입니다.
+ * - 선택 시 드롭다운을 닫은 후, 전달받은 `onClick` 콜백을 실행합니다.
+ *
+ * @example
+ * ```tsx
+ * <ActionDropdownItem onClick={handleEdit}>
+ *   수정하기
+ * </ActionDropdownItem>
+ * ```
+ */
+export default function ActionDropdownItem({
+  children,
+  onClick,
+  className,
+}: ActionDropdownItemProps) {
+  const { setIsOpen } = useDropdownBaseContext();
+
+  const executeAction = () => {
+    setIsOpen(false);
+    onClick();
+  };
+
+  //TODO: 키보드 접근성 개선
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    const key = e.key;
+
+    if (key === 'Enter' || key === ' ') {
+      e.preventDefault();
+      executeAction();
+    }
+  };
+
+  return (
+    <button
+      role="menuitem"
+      type="button"
+      className={cn(dropdownItemBase, dropdownItemHoverBase, dropdownItemShadowStyle, className)}
+      onKeyDown={handleKeyDown}
+      onClick={executeAction}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/shared/ui/dropdown/action/ActionDropdownTrigger.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdownTrigger.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { WithChildren } from '@/shared/types/common';
+import useDropdownBaseContext from '@/shared/ui/dropdown/hooks/useDropdownBaseContext';
+
+type ActionDropdownTriggerProps = WithChildren & {
+  /** 트리거 버튼에 추가로 적용할 스타일 */
+  className?: string;
+  /** 트리거 내부 콘텐츠가 아이콘일때 적용할 aria-label */
+  ariaLabel?: string;
+};
+
+/**
+ * ## ActionDropdownTrigger
+ *
+ * ActionDropdown의 트리거 버튼 컴포넌트입니다.
+ *
+ * - 클릭 시 드롭다운의 open 상태를 토글합니다.
+ * - `button` 요소 기반으로 기본 키보드 접근성을 제공합니다.
+ *
+ * @example
+ * ```tsx
+ * <ActionDropdownTrigger ariaLabel="메뉴 열기">
+ *   <MenuIcon aria-hidden className="h-6 w-6" />
+ * </ActionDropdownTrigger>
+ * ```
+ */
+
+export default function ActionDropdownTrigger({
+  children,
+  className,
+  ariaLabel,
+}: ActionDropdownTriggerProps) {
+  const { isOpen, setIsOpen } = useDropdownBaseContext();
+
+  return (
+    <button
+      type="button"
+      aria-haspopup="menu"
+      aria-label={ariaLabel}
+      aria-expanded={isOpen}
+      className={className}
+      onClick={() => setIsOpen((prev) => !prev)}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/shared/ui/dropdown/action/ActionDropdownTrigger.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdownTrigger.tsx
@@ -11,7 +11,7 @@ type ActionDropdownTriggerProps = WithChildren & {
 };
 
 /**
- * ## ActionDropdownTrigger
+ * ActionDropdownTrigger
  *
  * ActionDropdown의 트리거 버튼 컴포넌트입니다.
  *
@@ -25,7 +25,6 @@ type ActionDropdownTriggerProps = WithChildren & {
  * </ActionDropdownTrigger>
  * ```
  */
-
 export default function ActionDropdownTrigger({
   children,
   className,

--- a/src/shared/ui/dropdown/action/index.ts
+++ b/src/shared/ui/dropdown/action/index.ts
@@ -1,0 +1,4 @@
+export { default as ActionDropdown } from './ActionDropdown';
+export { default as ActionDropdownContent } from './ActionDropdownContent';
+export { default as ActionDropdownItem } from './ActionDropdownItem';
+export { default as ActionDropdownTrigger } from './ActionDropdownTrigger';


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #58 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### ActionDropdown 구현
- 메뉴형 드롭다운 컴포넌트로 사용
- 공통 BaseDropdown 재사용

- 헤더 (마이페이지, 로그아웃)에서 사용
- 상세 페이지(수정, 삭제)에서 사용

### 스크린샷 (선택)
<img width="208" height="297" alt="image" src="https://github.com/user-attachments/assets/9070c9ae-dc40-4daa-856a-8114714efd9e" />
<img width="215" height="114" alt="image" src="https://github.com/user-attachments/assets/db2a36fd-ed5b-4351-9fd5-4ca99c52a9da" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

키보드 접근성 및 esc 기능은 다음 PR로 올리겠습니다!
feat/#27에서 분기해서 온 PR이기 때문에 feat/#27로 머지되게 했습니다!