### PR TITLE
[✨ Feat/#63] 공통 필터 버튼 컴포넌트 구현

### DIFF
--- a/src/features/activity/ui/CategoryFilter.tsx
+++ b/src/features/activity/ui/CategoryFilter.tsx
@@ -1,0 +1,44 @@
+import FilterButton from '@/shared/ui/filter-button/FilterButton';
+
+const CATEGORY_LIST = ['전체', '문화 · 예술', '식음료', '투어', '관광', '웰빙'];
+
+interface CategoryFilterProps {
+  selectedCategory: string;
+  onChangeCategory: (category: string) => void;
+}
+
+/**
+ * 체험 도메인의 카테고리를 필터링하는 컴포넌트입니다.
+ * * @example
+ * ```tsx
+ * import { useState } from 'react';
+ * import CategoryFilter from '@/features/activity/ui/CategoryFilter';
+ * export default function SearchPage() {
+ * const [category, setCategory] = useState('전체');
+ * return (
+ * <CategoryFilter
+ * selectedCategory={category}
+ * onChangeCategory={setCategory}
+ * />
+ * );
+ * }
+ * ```
+ */
+export default function CategoryFilter({
+  selectedCategory,
+  onChangeCategory,
+}: CategoryFilterProps) {
+  return (
+    <div className="flex flex-wrap gap-4">
+      {CATEGORY_LIST.map((category) => (
+        <FilterButton
+          key={category}
+          isSelected={selectedCategory === category}
+          onClick={() => onChangeCategory(category)}
+        >
+          {category}
+        </FilterButton>
+      ))}
+    </div>
+  );
+}

--- a/src/features/activity/ui/CategoryFilter.tsx
+++ b/src/features/activity/ui/CategoryFilter.tsx
@@ -2,10 +2,10 @@ import FilterButton from '@/shared/ui/filter-button/FilterButton';
 
 const CATEGORY_LIST = ['전체', '문화 · 예술', '식음료', '투어', '관광', '웰빙'];
 
-interface CategoryFilterProps {
+type CategoryFilterProps = {
   selectedCategory: string;
   onChangeCategory: (category: string) => void;
-}
+};
 
 /**
  * 체험 도메인의 카테고리를 필터링하는 컴포넌트입니다.

--- a/src/features/activity/ui/category-filter/CategoryFilter.stories.tsx
+++ b/src/features/activity/ui/category-filter/CategoryFilter.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import CategoryFilter from '@/features/activity/ui/category-filter/CategoryFilter';
+
+const meta: Meta<typeof CategoryFilter> = {
+  title: 'Features/Activity/CategoryFilter',
+  component: CategoryFilter,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CategoryFilter>;
+
+export const Default: Story = {
+  render: () => {
+    function StoryWrapper() {
+      const [category, setCategory] = useState('전체');
+      return (
+        <div className="w-fit rounded-xl bg-gray-50 p-8">
+          <CategoryFilter selectedCategory={category} onChangeCategory={setCategory} />
+        </div>
+      );
+    }
+    return <StoryWrapper />;
+  },
+};

--- a/src/features/activity/ui/category-filter/CategoryFilter.tsx
+++ b/src/features/activity/ui/category-filter/CategoryFilter.tsx
@@ -12,7 +12,7 @@ type CategoryFilterProps = {
  * * @example
  * ```tsx
  * import { useState } from 'react';
- * import CategoryFilter from '@/features/activity/ui/CategoryFilter';
+ * import CategoryFilter from '@/features/activity/ui/category-filter/CategoryFilter';
  * export default function SearchPage() {
  * const [category, setCategory] = useState('전체');
  * return (

--- a/src/features/reservation/ui/ReservationStatusFilter.tsx
+++ b/src/features/reservation/ui/ReservationStatusFilter.tsx
@@ -1,0 +1,48 @@
+import FilterButton from '@/shared/ui/filter-button/FilterButton';
+
+const STATUS_LIST = ['예약 완료', '예약 취소', '예약 승인', '예약 거절', '체험 완료'];
+
+interface ReservationStatusFilterProps {
+  selectedStatus: string;
+  onSelectStatus: (status: string) => void;
+}
+
+/**
+ * 예약 도메인의 예약 상태를 필터링하는 컴포넌트입니다.
+ * 이미 선택된 상태 버튼을 다시 클릭하면 필터를 해제합니다.
+ * * @example
+ * ```tsx
+ * import { useState } from 'react';
+ * import ReservationStatusFilter from '@/features/reservation/ui/ReservationStatusFilter';
+ * export default function MyReservationPage() {
+ * const [status, setStatus] = useState('');
+ * return (
+ * <ReservationStatusFilter
+ * selectedStatus={status}
+ * onSelectStatus={setStatus}
+ * />
+ * );
+ * }
+ * ```
+ */
+export default function ReservationStatusFilter({
+  selectedStatus,
+  onSelectStatus,
+}: ReservationStatusFilterProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {STATUS_LIST.map((status) => (
+        <FilterButton
+          key={status}
+          isSelected={selectedStatus === status}
+          onClick={() => {
+            // 이미 선택된 것을 누르면 선택 해제, 아니면 해당 상태로 변경
+            onSelectStatus(selectedStatus === status ? '' : status);
+          }}
+        >
+          {status}
+        </FilterButton>
+      ))}
+    </div>
+  );
+}

--- a/src/features/reservation/ui/ReservationStatusFilter.tsx
+++ b/src/features/reservation/ui/ReservationStatusFilter.tsx
@@ -2,10 +2,10 @@ import FilterButton from '@/shared/ui/filter-button/FilterButton';
 
 const STATUS_LIST = ['예약 완료', '예약 취소', '예약 승인', '예약 거절', '체험 완료'];
 
-interface ReservationStatusFilterProps {
+type ReservationStatusFilterProps = {
   selectedStatus: string;
   onSelectStatus: (status: string) => void;
-}
+};
 
 /**
  * 예약 도메인의 예약 상태를 필터링하는 컴포넌트입니다.

--- a/src/features/reservation/ui/status-filter/StatusFilter.stories.tsx
+++ b/src/features/reservation/ui/status-filter/StatusFilter.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import StatusFilter from '@/features/reservation/ui/status-filter/StatusFilter';
+
+const meta: Meta<typeof StatusFilter> = {
+  title: 'Features/Reservation/StatusFilter',
+  component: StatusFilter,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof StatusFilter>;
+
+export const Default: Story = {
+  render: () => {
+    function StoryWrapper() {
+      const [status, setStatus] = useState('');
+      return (
+        <div className="w-fit rounded-xl bg-gray-50 p-8">
+          <StatusFilter selectedStatus={status} onSelectStatus={setStatus} />
+        </div>
+      );
+    }
+    return <StoryWrapper />;
+  },
+};

--- a/src/features/reservation/ui/status-filter/StatusFilter.tsx
+++ b/src/features/reservation/ui/status-filter/StatusFilter.tsx
@@ -2,7 +2,7 @@ import FilterButton from '@/shared/ui/filter-button/FilterButton';
 
 const STATUS_LIST = ['예약 완료', '예약 취소', '예약 승인', '예약 거절', '체험 완료'];
 
-type ReservationStatusFilterProps = {
+type StatusFilterProps = {
   selectedStatus: string;
   onSelectStatus: (status: string) => void;
 };
@@ -13,11 +13,11 @@ type ReservationStatusFilterProps = {
  * * @example
  * ```tsx
  * import { useState } from 'react';
- * import ReservationStatusFilter from '@/features/reservation/ui/ReservationStatusFilter';
+ * import StatusFilter from '@/features/reservation/ui/status-filter/StatusFilter';
  * export default function MyReservationPage() {
  * const [status, setStatus] = useState('');
  * return (
- * <ReservationStatusFilter
+ * <StatusFilter
  * selectedStatus={status}
  * onSelectStatus={setStatus}
  * />
@@ -25,10 +25,7 @@ type ReservationStatusFilterProps = {
  * }
  * ```
  */
-export default function ReservationStatusFilter({
-  selectedStatus,
-  onSelectStatus,
-}: ReservationStatusFilterProps) {
+export default function StatusFilter({ selectedStatus, onSelectStatus }: StatusFilterProps) {
   return (
     <div className="flex flex-wrap gap-2">
       {STATUS_LIST.map((status) => (

--- a/src/shared/ui/filter-button/FilterButton.stories.tsx
+++ b/src/shared/ui/filter-button/FilterButton.stories.tsx
@@ -1,7 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
-import { useState } from 'react';
-import ActivityCategoryFilter from '@/features/activity/ui/CategoryFilter';
-import ReservationStatusFilter from '@/features/reservation/ui/ReservationStatusFilter';
 import FilterButton from '@/shared/ui/filter-button/FilterButton';
 
 const meta: Meta<typeof FilterButton> = {
@@ -28,31 +25,4 @@ export const Playground: Story = {
       <FilterButton {...args} />
     </div>
   ),
-};
-
-export const FilterGroup: Story = {
-  render: () => {
-    function FilterGroupWrapper() {
-      const [category, setCategory] = useState('전체');
-      const [status, setStatus] = useState('');
-
-      return (
-        <div className="flex w-fit flex-col gap-8 rounded-xl bg-gray-50 p-8">
-          {/* 카테고리 필터 그룹 */}
-          <div className="flex flex-col gap-3">
-            <h3 className="typo-16-bold text-gray-400">Activity Category</h3>
-            <ActivityCategoryFilter selectedCategory={category} onChangeCategory={setCategory} />
-          </div>
-
-          {/* 예약 상태 필터 그룹 */}
-          <div className="flex flex-col gap-3">
-            <h3 className="typo-16-bold text-gray-400">Reservation Status</h3>
-            <ReservationStatusFilter selectedStatus={status} onSelectStatus={setStatus} />
-          </div>
-        </div>
-      );
-    }
-
-    return <FilterGroupWrapper />;
-  },
 };

--- a/src/shared/ui/filter-button/FilterButton.stories.tsx
+++ b/src/shared/ui/filter-button/FilterButton.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import ActivityCategoryFilter from '@/features/activity/ui/CategoryFilter';
+import ReservationStatusFilter from '@/features/reservation/ui/ReservationStatusFilter';
+import FilterButton from '@/shared/ui/filter-button/FilterButton';
+
+const meta: Meta<typeof FilterButton> = {
+  title: 'Shared/FilterButton',
+  component: FilterButton,
+  tags: ['autodocs'],
+  argTypes: {
+    isSelected: { control: 'boolean', description: '선택 활성화 여부' },
+    children: { control: 'text', description: '필터 텍스트 내용' },
+    onClick: { action: 'clicked', description: '클릭 이벤트 핸들러' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FilterButton>;
+
+export const Playground: Story = {
+  args: {
+    children: '예약 완료',
+    isSelected: false,
+  },
+  render: (args) => (
+    <div className="w-fit rounded-xl bg-gray-50 p-8">
+      <FilterButton {...args} />
+    </div>
+  ),
+};
+
+export const FilterGroup: Story = {
+  render: () => {
+    function FilterGroupWrapper() {
+      const [category, setCategory] = useState('전체');
+      const [status, setStatus] = useState('');
+
+      return (
+        <div className="flex w-fit flex-col gap-8 rounded-xl bg-gray-50 p-8">
+          {/* 카테고리 필터 그룹 */}
+          <div className="flex flex-col gap-3">
+            <h3 className="typo-16-bold text-gray-400">Activity Category</h3>
+            <ActivityCategoryFilter selectedCategory={category} onChangeCategory={setCategory} />
+          </div>
+
+          {/* 예약 상태 필터 그룹 */}
+          <div className="flex flex-col gap-3">
+            <h3 className="typo-16-bold text-gray-400">Reservation Status</h3>
+            <ReservationStatusFilter selectedStatus={status} onSelectStatus={setStatus} />
+          </div>
+        </div>
+      );
+    }
+
+    return <FilterGroupWrapper />;
+  },
+};

--- a/src/shared/ui/filter-button/FilterButton.tsx
+++ b/src/shared/ui/filter-button/FilterButton.tsx
@@ -26,6 +26,7 @@ export default function FilterButton({
   return (
     <button
       type="button"
+      aria-pressed={isSelected}
       className={cn(
         // 기본 상태
         'rounded-full px-4 py-2.5 transition-colors',

--- a/src/shared/ui/filter-button/FilterButton.tsx
+++ b/src/shared/ui/filter-button/FilterButton.tsx
@@ -1,0 +1,42 @@
+import type { ComponentProps } from 'react';
+import { cn } from '@/shared/utils/cn';
+
+type FilterButtonProps = ComponentProps<'button'> & {
+  isSelected?: boolean;
+};
+
+/**
+ * 목록을 필터링할 때 사용하는 공통 FilterButton 컴포넌트입니다.
+ * @example
+ * ```tsx
+ * <FilterButton isSelected={true} onClick={상태 변경 로직}>
+ * 예약 완료
+ * </FilterButton>
+ * ```
+ */
+export default function FilterButton({
+  children,
+  isSelected = false,
+  className,
+  ...props
+}: FilterButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        // 기본 상태
+        'rounded-full px-4 py-2.5 transition-colors',
+        'typo-16-medium text-gray-950',
+        'border',
+        // 선택 상태일 경우
+        isSelected
+          ? 'border-primary-500 bg-primary-100'
+          : 'border-gray-200 bg-white hover:bg-gray-50',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/shared/ui/filter-button/FilterButton.tsx
+++ b/src/shared/ui/filter-button/FilterButton.tsx
@@ -5,6 +5,9 @@ type FilterButtonProps = ComponentProps<'button'> & {
   isSelected?: boolean;
 };
 
+const selectedStyle = 'border-primary-500 bg-primary-100';
+const defaultStyle = 'border-gray-200 bg-white hover:bg-gray-50';
+
 /**
  * 목록을 필터링할 때 사용하는 공통 FilterButton 컴포넌트입니다.
  * @example
@@ -29,9 +32,7 @@ export default function FilterButton({
         'typo-16-medium text-gray-950',
         'border',
         // 선택 상태일 경우
-        isSelected
-          ? 'border-primary-500 bg-primary-100'
-          : 'border-gray-200 bg-white hover:bg-gray-50',
+        isSelected ? selectedStyle : defaultStyle,
         className
       )}
       {...props}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #63 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- `FilterButton`은 어떤 데이터가 들어오는지 모르는 순수 UI 컴포넌트로 동작하도록 구현
- 실제 도메인에 해당하는 데이터(`CATEGORY_LIST`, `STATUS_LIST`)는 분리하여, `features` 디렉토리 하위의 각 도메인(체험, 예약) `ui` 폴더 안에 `CategoryFilter.tsx`와 `ReservationStatusFilter.tsx`로 구현

### 스크린샷 (선택)

<img width="270" height="110" alt="image" src="https://github.com/user-attachments/assets/0e942bcb-b5d1-42df-9d9f-066c25c6a34d" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

해당 컴포넌트가 검색/체험 페이지, 예약내역 페이지에 쓰이면서 리스트에 들어가는 내용이 해당 도메인에 관련된 내용인것 같아서 `features` 폴더 아래 배치했는데 괜찮은 걸까요? 아니면 `shared/ui/filter-button` 폴더 아래 나란히 배치하는 게 나을까요?
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
