### PR TITLE
[✨Feat/#57] 공통 탭바 컴포넌트 구현

### DIFF
--- a/src/shared/ui/tab-bar/TabBar.stories.tsx
+++ b/src/shared/ui/tab-bar/TabBar.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 import { useState } from 'react';
-import TabBar from './TabBar';
+import TabBar from '@/shared/ui/tab-bar/TabBar';
 
 const meta: Meta<typeof TabBar> = {
   title: 'Shared/TabBar',

--- a/src/shared/ui/tab-bar/TabBar.stories.tsx
+++ b/src/shared/ui/tab-bar/TabBar.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof meta>;
 // 체험 상세 페이지
 export const ActivityDetail: Story = {
   render: (args) => {
-    const [activeTab, setActiveTab] = useState('체험 설명');
+    const [activeTab, setActiveTab] = useState('description');
     return <TabBar {...args} activeTab={activeTab} onTabChange={setActiveTab} />;
   },
   args: {
@@ -30,7 +30,7 @@ export const ActivityDetail: Story = {
 // 예약 현황 (count 포함)
 export const ReservationStatus: Story = {
   render: (args) => {
-    const [activeTab, setActiveTab] = useState('신청');
+    const [activeTab, setActiveTab] = useState('pending');
     return <TabBar {...args} activeTab={activeTab} onTabChange={setActiveTab} />;
   },
   args: {

--- a/src/shared/ui/tab-bar/TabBar.stories.tsx
+++ b/src/shared/ui/tab-bar/TabBar.stories.tsx
@@ -18,7 +18,11 @@ export const ActivityDetail: Story = {
     return <TabBar {...args} activeTab={activeTab} onTabChange={setActiveTab} />;
   },
   args: {
-    tabs: [{ label: '체험 설명' }, { label: '오시는 길' }, { label: '체험 후기' }],
+    tabs: [
+      { id: 'description', label: '체험 설명' },
+      { id: 'location', label: '오시는 길' },
+      { id: 'review', label: '체험 후기' },
+    ],
     tabClassName: 'flex-1 md:flex-none md:w-[130px]',
   },
 };
@@ -31,10 +35,10 @@ export const MyPage: Story = {
   },
   args: {
     tabs: [
-      { label: '내 정보' },
-      { label: '예약내역' },
-      { label: '내 체험 관리' },
-      { label: '예약 현황' },
+      { id: 'info', label: '내 정보' },
+      { id: 'reservation-list', label: '예약내역' },
+      { id: 'activity', label: '내 체험 관리' },
+      { id: 'reservation-status', label: '예약 현황' },
     ],
     tabClassName: 'flex-1',
   },
@@ -48,9 +52,9 @@ export const ReservationStatus: Story = {
   },
   args: {
     tabs: [
-      { label: '신청', count: 3 },
-      { label: '승인', count: 1 },
-      { label: '거절', count: 1 },
+      { id: 'pending', label: '신청', count: 3 },
+      { id: 'approved', label: '승인', count: 1 },
+      { id: 'rejected', label: '거절', count: 1 },
     ],
     tabClassName: 'flex-1',
   },

--- a/src/shared/ui/tab-bar/TabBar.stories.tsx
+++ b/src/shared/ui/tab-bar/TabBar.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import TabBar from '@/shared/ui/tab-bar/TabBar';
 
 const meta: Meta<typeof TabBar> = {
-  title: 'Shared/TabBar',
+  title: 'Shared/TabBar/TabBar',
   component: TabBar,
   tags: ['autodocs'],
 };
@@ -24,23 +24,6 @@ export const ActivityDetail: Story = {
       { id: 'review', label: '체험 후기' },
     ],
     tabClassName: 'flex-1 md:flex-none md:w-[130px]',
-  },
-};
-
-// 마이페이지 (모바일)
-export const MyPage: Story = {
-  render: (args) => {
-    const [activeTab, setActiveTab] = useState('내 정보');
-    return <TabBar {...args} activeTab={activeTab} onTabChange={setActiveTab} />;
-  },
-  args: {
-    tabs: [
-      { id: 'info', label: '내 정보' },
-      { id: 'reservation-list', label: '예약내역' },
-      { id: 'activity', label: '내 체험 관리' },
-      { id: 'reservation-status', label: '예약 현황' },
-    ],
-    tabClassName: 'flex-1',
   },
 };
 

--- a/src/shared/ui/tab-bar/TabBar.stories.tsx
+++ b/src/shared/ui/tab-bar/TabBar.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import TabBar from './TabBar';
+
+const meta: Meta<typeof TabBar> = {
+  title: 'Shared/TabBar',
+  component: TabBar,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 체험 상세 페이지
+export const ActivityDetail: Story = {
+  render: (args) => {
+    const [activeTab, setActiveTab] = useState('체험 설명');
+    return <TabBar {...args} activeTab={activeTab} onTabChange={setActiveTab} />;
+  },
+  args: {
+    tabs: [{ label: '체험 설명' }, { label: '오시는 길' }, { label: '체험 후기' }],
+    tabClassName: 'flex-1 md:flex-none md:w-[130px]',
+  },
+};
+
+// 마이페이지 (모바일)
+export const MyPage: Story = {
+  render: (args) => {
+    const [activeTab, setActiveTab] = useState('내 정보');
+    return <TabBar {...args} activeTab={activeTab} onTabChange={setActiveTab} />;
+  },
+  args: {
+    tabs: [
+      { label: '내 정보' },
+      { label: '예약내역' },
+      { label: '내 체험 관리' },
+      { label: '예약 현황' },
+    ],
+    tabClassName: 'flex-1',
+  },
+};
+
+// 예약 현황 (count 포함)
+export const ReservationStatus: Story = {
+  render: (args) => {
+    const [activeTab, setActiveTab] = useState('신청');
+    return <TabBar {...args} activeTab={activeTab} onTabChange={setActiveTab} />;
+  },
+  args: {
+    tabs: [
+      { label: '신청', count: 3 },
+      { label: '승인', count: 1 },
+      { label: '거절', count: 1 },
+    ],
+    tabClassName: 'flex-1',
+  },
+};

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -89,7 +89,7 @@ export default function TabBar({ tabs, activeTab, onTabChange, tabClassName }: T
           )}
         >
           {tab.label}
-          {tab.count !== undefined && <span> {tab.count}</span>}
+          {tab.count !== undefined && <span aria-label={`${tab.count}건`}> {tab.count}</span>}
         </button>
       ))}
     </div>

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -81,6 +81,7 @@ export default function TabBar({ tabs, activeTab, onTabChange, tabClassName }: T
         <button
           key={tab.label}
           onClick={() => activeTab !== tab.label && onTabChange(tab.label)}
+          type="button"
           role="tab"
           aria-selected={activeTab === tab.label}
           className={cn(

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cva } from 'class-variance-authority';
+import { tabVariants } from '@/shared/ui/tab-bar/styles/tabVariants';
 import { cn } from '@/shared/utils/cn';
 
 type Tab = {
@@ -16,26 +16,15 @@ type TabBarProps = {
   tabClassName?: string;
 };
 
-const tabVariants = cva(
-  'h-10 cursor-pointer flex items-center justify-center -mb-px', // 모든 탭에 공통으로 적용될 스타일
-  {
-    variants: {
-      state: {
-        active: 'typo-16-bold text-primary-500 border-b-2 border-primary-500', // 활성화 탭
-        inactive: 'typo-16-medium text-gray-500 hover:text-gray-700 border-b-2 border-transparent', // 비활성화 탭
-      },
-    },
-  }
-);
-
 /**
  * 탭 선택 시 스크롤 이동, 콘텐츠 전환, 페이지 이동 등 다양한 방식으로 동작하는 탭바 공통 컴포넌트입니다.
  *
- * 체험 상세, 마이페이지, 예약 현황 페이지에서 사용됩니다.
- * count prop으로 상태별 체험 개수를 함께 표시할 수 있습니다.
+ * 체험 상세, 예약 현황 페이지에서 사용됩니다.
+ * URL 이동이 필요한 경우 TabNav 컴포넌트를 사용해주세요.
+ * count로 상태별 체험 개수를 함께 표시할 수 있습니다.
  * tabClassName으로 각 탭 버튼의 너비를 외부에서 지정할 수 있습니다.
  *
- * @param tabs - 탭 목록 (label: 탭 이름, count: 상태별 체험 개수)
+ * @param tabs - 탭 목록 (id: 고유 식별자, label: 탭 이름, count: 상태별 체험 개수)
  * @param activeTab - 현재 활성화된 탭 이름
  * @param onTabChange - 탭 변경 시 호출되는 콜백 함수
  * @param tabClassName - 각 탭에 추가로 적용할 클래스 이름
@@ -44,31 +33,15 @@ const tabVariants = cva(
  * ```tsx
  * // 체험 상세 페이지 (스크롤 이동)
  * <TabBar
- *   tabs={[{ label: '체험 설명' }, { label: '오시는 길' }, { label: '체험 후기' }]}
+ *   tabs={[{ id: 'description', label: '체험 설명' }, ...]}
  *   activeTab={activeTab}
  *   onTabChange={handleTabChange}
  *   tabClassName="flex-1 md:flex-none md:w-[130px]"
  * />
  *
- * // 마이페이지 (URL 이동)
- * <TabBar
- *   tabs={[{ label: '내 정보' }, { label: '예약내역' }, { label: '내 체험 관리' }, { label: '예약 현황' }]}
- *   activeTab={activeTab}
- *   onTabChange={(tab) => {
- *     const pathMap: Record<string, string> = {
- *       '내 정보': '/mypage/info',
- *       '예약내역': '/mypage/reservation-list',
- *       '내 체험 관리': '/mypage/activity',
- *       '예약 현황': '/mypage/reservation-status',
- *     };
- *    router.push(pathMap[tab]);
- *   }}
- *   tabClassName="flex-1"
- * />
- *
  * // 예약 현황 (콘텐츠 전환, count 포함)
  * <TabBar
- *   tabs={[{ label: '신청', count: 3 }, { label: '승인', count: 1 }, { label: '거절', count: 1 }]}
+ *   tabs={[{ id: 'pending', label: '신청', count: 3 }, ...]}
  *   activeTab={activeTab}
  *   onTabChange={handleTabChange}
  *   tabClassName="flex-1"

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { tabVariants } from '@/shared/ui/tab-bar/styles/tabVariants';
+import { handleTabKeyDown } from '@/shared/ui/tab-bar/utils/tabKeyboardNavigation';
 import { cn } from '@/shared/utils/cn';
 
 type Tab = {
@@ -51,10 +52,15 @@ type TabBarProps = {
 export default function TabBar({ tabs, activeTab, onTabChange, tabClassName }: TabBarProps) {
   return (
     <div className="flex w-full border-b border-gray-100" role="tablist" aria-label="탭 목록">
-      {tabs.map((tab) => (
+      {tabs.map((tab, index) => (
         <button
           key={tab.id}
           onClick={() => activeTab !== tab.label && onTabChange(tab.label)}
+          onKeyDown={(e) =>
+            handleTabKeyDown(e, tabs.length, index, (nextIndex) => {
+              onTabChange(tabs[nextIndex].label);
+            })
+          }
           type="button"
           role="tab"
           aria-selected={activeTab === tab.label}

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -80,7 +80,7 @@ export default function TabBar({ tabs, activeTab, onTabChange, tabClassName }: T
       {tabs.map((tab) => (
         <button
           key={tab.label}
-          onClick={() => onTabChange(tab.label)}
+          onClick={() => activeTab !== tab.label && onTabChange(tab.label)}
           role="tab"
           aria-selected={activeTab === tab.label}
           className={cn(

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -4,6 +4,7 @@ import { cva } from 'class-variance-authority';
 import { cn } from '@/shared/utils/cn';
 
 type Tab = {
+  id: string;
   label: string;
   count?: number;
 };
@@ -79,7 +80,7 @@ export default function TabBar({ tabs, activeTab, onTabChange, tabClassName }: T
     <div className="flex w-full border-b border-gray-100" role="tablist" aria-label="탭 목록">
       {tabs.map((tab) => (
         <button
-          key={tab.label}
+          key={tab.id}
           onClick={() => activeTab !== tab.label && onTabChange(tab.label)}
           type="button"
           role="tab"

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -16,12 +16,12 @@ type TabBarProps = {
 };
 
 const tabVariants = cva(
-  'h-10 cursor-pointer', // 모든 탭에 공통으로 적용될 스타일
+  'h-10 cursor-pointer flex items-center justify-center -mb-px', // 모든 탭에 공통으로 적용될 스타일
   {
     variants: {
       state: {
         active: 'typo-16-bold text-primary-500 border-b-2 border-primary-500', // 활성화 탭
-        inactive: 'typo-16-medium text-gray-500 hover:text-gray-700', // 비활성화 탭
+        inactive: 'typo-16-medium text-gray-500 hover:text-gray-700 border-b-2 border-transparent', // 비활성화 탭
       },
     },
   }

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { cva } from 'class-variance-authority';
+import { cn } from '@/shared/utils/cn';
+
+type Tab = {
+  label: string;
+  count?: number;
+};
+
+type TabBarProps = {
+  tabs: Tab[];
+  activeTab: string;
+  onTabChange: (tabLabel: string) => void;
+  tabClassName?: string;
+  className?: string;
+};
+
+const tabVariants = cva(
+  'h-10 cursor-pointer', // 모든 탭에 공통으로 적용될 스타일
+  {
+    variants: {
+      state: {
+        active: 'typo-16-bold text-primary-500 border-b-2 border-primary-500', // 활성화 탭
+        inactive: 'typo-16-medium text-gray-500 hover:text-gray-700', // 비활성화 탭
+      },
+    },
+  }
+);
+
+/**
+ * 탭 선택 시 스크롤 이동, 콘텐츠 전환, 페이지 이동 등 다양한 방식으로 동작하는 탭바 공통 컴포넌트입니다.
+ *
+ * 체험 상세, 마이페이지, 예약 현황 페이지에서 사용됩니다.
+ * count prop으로 상태별 체험 개수를 함께 표시할 수 있습니다.
+ * tabClassName으로 각 탭 버튼의 너비를 외부에서 지정할 수 있습니다.
+ *
+ * @param tabs - 탭 목록 (label: 탭 이름, count: 상태별 체험 개수)
+ * @param activeTab - 현재 활성화된 탭 이름
+ * @param onTabChange - 탭 변경 시 호출되는 콜백 함수
+ * @param tabClassName - 각 탭에 추가로 적용할 클래스 이름
+ * @param className - 탭바 전체에 추가로 적용할 클래스 이름
+ *
+ * @example
+ * ```tsx
+ * // 체험 상세 페이지 (스크롤 이동)
+ * <TabBar
+ *   tabs={[{ label: '체험 설명' }, { label: '오시는 길' }, { label: '체험 후기' }]}
+ *   activeTab={activeTab}
+ *   onTabChange={handleTabChange}
+ *   tabClassName="flex-1 md:flex-none md:w-[130px]"
+ * />
+ *
+ * // 마이페이지 (URL 이동)
+ * <TabBar
+ *   tabs={[{ label: '내 정보' }, { label: '예약내역' }, { label: '내 체험 관리' }, { label: '예약 현황' }]}
+ *   activeTab={activeTab}
+ *   onTabChange={(tab) => {
+ *     const pathMap: Record<string, string> = {
+ *       '내 정보': '/mypage/info',
+ *       '예약내역': '/mypage/reservation-list',
+ *       '내 체험 관리': '/mypage/activity',
+ *       '예약 현황': '/mypage/reservation-status',
+ *     };
+ *    router.push(pathMap[tab]);
+ *   }}
+ *   tabClassName="flex-1"
+ * />
+ *
+ * // 예약 현황 (콘텐츠 전환, count 포함)
+ * <TabBar
+ *   tabs={[{ label: '신청', count: 3 }, { label: '승인', count: 1 }, { label: '거절', count: 1 }]}
+ *   activeTab={activeTab}
+ *   onTabChange={handleTabChange}
+ *   tabClassName="flex-1"
+ * />
+ * ```
+ */
+export default function TabBar({
+  tabs,
+  activeTab,
+  onTabChange,
+  tabClassName,
+  className,
+}: TabBarProps) {
+  return (
+    <div
+      className={cn('flex w-full border-b border-gray-100', className)}
+      role="tablist"
+      aria-label="탭 목록"
+    >
+      {tabs.map((tab) => (
+        <button
+          key={tab.label}
+          onClick={() => onTabChange(tab.label)}
+          role="tab"
+          aria-selected={activeTab === tab.label}
+          className={cn(
+            tabVariants({ state: activeTab === tab.label ? 'active' : 'inactive' }),
+            tabClassName
+          )}
+        >
+          {tab.label}
+          {tab.count !== undefined && <span> {tab.count}</span>}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -13,7 +13,6 @@ type TabBarProps = {
   activeTab: string;
   onTabChange: (tabLabel: string) => void;
   tabClassName?: string;
-  className?: string;
 };
 
 const tabVariants = cva(
@@ -39,7 +38,6 @@ const tabVariants = cva(
  * @param activeTab - 현재 활성화된 탭 이름
  * @param onTabChange - 탭 변경 시 호출되는 콜백 함수
  * @param tabClassName - 각 탭에 추가로 적용할 클래스 이름
- * @param className - 탭바 전체에 추가로 적용할 클래스 이름
  *
  * @example
  * ```tsx
@@ -76,19 +74,9 @@ const tabVariants = cva(
  * />
  * ```
  */
-export default function TabBar({
-  tabs,
-  activeTab,
-  onTabChange,
-  tabClassName,
-  className,
-}: TabBarProps) {
+export default function TabBar({ tabs, activeTab, onTabChange, tabClassName }: TabBarProps) {
   return (
-    <div
-      className={cn('flex w-full border-b border-gray-100', className)}
-      role="tablist"
-      aria-label="탭 목록"
-    >
+    <div className="flex w-full border-b border-gray-100" role="tablist" aria-label="탭 목록">
       {tabs.map((tab) => (
         <button
           key={tab.label}

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -64,7 +64,7 @@ export default function TabBar({ tabs, activeTab, onTabChange, tabClassName }: T
           )}
         >
           {tab.label}
-          {tab.count !== undefined && <span aria-label={`${tab.count}건`}> {tab.count}</span>}
+          {tab.count !== undefined && <span aria-label={`${tab.count}건`}>&nbsp;{tab.count}</span>}
         </button>
       ))}
     </div>

--- a/src/shared/ui/tab-bar/TabBar.tsx
+++ b/src/shared/ui/tab-bar/TabBar.tsx
@@ -55,17 +55,17 @@ export default function TabBar({ tabs, activeTab, onTabChange, tabClassName }: T
       {tabs.map((tab, index) => (
         <button
           key={tab.id}
-          onClick={() => activeTab !== tab.label && onTabChange(tab.label)}
+          onClick={() => activeTab !== tab.id && onTabChange(tab.id)}
           onKeyDown={(e) =>
             handleTabKeyDown(e, tabs.length, index, (nextIndex) => {
-              onTabChange(tabs[nextIndex].label);
+              onTabChange(tabs[nextIndex].id);
             })
           }
           type="button"
           role="tab"
-          aria-selected={activeTab === tab.label}
+          aria-selected={activeTab === tab.id}
           className={cn(
-            tabVariants({ state: activeTab === tab.label ? 'active' : 'inactive' }),
+            tabVariants({ state: activeTab === tab.id ? 'active' : 'inactive' }),
             tabClassName
           )}
         >

--- a/src/shared/ui/tab-bar/TabNav.stories.tsx
+++ b/src/shared/ui/tab-bar/TabNav.stories.tsx
@@ -6,11 +6,6 @@ const meta: Meta<typeof TabNav> = {
   component: TabNav,
   tags: ['autodocs'],
   parameters: {
-    docs: {
-      description: {
-        component: 'URL 기반으로 동작하여 Storybook에서는 탭 전환 동작을 확인할 수 없습니다.',
-      },
-    },
     nextjs: {
       appDirectory: true,
       navigation: {

--- a/src/shared/ui/tab-bar/TabNav.stories.tsx
+++ b/src/shared/ui/tab-bar/TabNav.stories.tsx
@@ -6,6 +6,11 @@ const meta: Meta<typeof TabNav> = {
   component: TabNav,
   tags: ['autodocs'],
   parameters: {
+    docs: {
+      description: {
+        component: 'URL 기반으로 동작하여 Storybook에서는 탭 전환 동작을 확인할 수 없습니다.',
+      },
+    },
     nextjs: {
       appDirectory: true,
       navigation: {

--- a/src/shared/ui/tab-bar/TabNav.stories.tsx
+++ b/src/shared/ui/tab-bar/TabNav.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import TabNav from '@/shared/ui/tab-bar/TabNav';
+
+const meta: Meta<typeof TabNav> = {
+  title: 'Shared/TabBar/TabNav',
+  component: TabNav,
+  tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/mypage/info',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 마이페이지 (모바일)
+export const MyPage: Story = {
+  args: {
+    tabs: [
+      { id: 'info', label: '내 정보', href: '/mypage/info' },
+      { id: 'reservation-list', label: '예약내역', href: '/mypage/reservation-list' },
+      { id: 'activity', label: '내 체험 관리', href: '/mypage/activity' },
+      { id: 'reservation-status', label: '예약 현황', href: '/mypage/reservation-status' },
+    ],
+    tabClassName: 'flex-1',
+  },
+};

--- a/src/shared/ui/tab-bar/TabNav.tsx
+++ b/src/shared/ui/tab-bar/TabNav.tsx
@@ -28,15 +28,10 @@ type TabNavProps = {
  *
  * @example
  * ```tsx
- * <TabNav
- *  tabs={[
- *    { id: 'info', label: '내 정보', href: '/mypage/info' },
- *    { id: 'reservation-list', label: '예약내역', href: '/mypage/reservations' },
- *    { id: 'activity', label: '내 체험 관리', href: '/mypage/activities' },
- *    { id: 'reservation-status', label: '예약 현황', href: '/mypage/reservation-status' },
- *  ]}
- *  tabClassName="flex-1"
- * />
+ * // 마이페이지 레이아웃에서 모바일 전용으로 사용
+ * <div className="md:hidden">
+ *   <TabNav tabs={TAB_ITEMS} tabClassName="flex-1" />
+ * </div>
  * ```
  */
 export default function TabNav({ tabs, tabClassName }: TabNavProps) {

--- a/src/shared/ui/tab-bar/TabNav.tsx
+++ b/src/shared/ui/tab-bar/TabNav.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { tabVariants } from '@/shared/ui/tab-bar/styles/tabVariants';
+import { cn } from '@/shared/utils/cn';
+
+type Tab = {
+  id: string;
+  label: string;
+  href: string;
+};
+
+type TabNavProps = {
+  tabs: Tab[];
+  tabClassName?: string;
+};
+
+/**
+ * URL 기반으로 동작하는 탭 네비게이션 공통 컴포넌트입니다.
+ *
+ * 마이페이지의 모바일 버전에서 사용되며, usePathname으로 현재 경로를 감지해 활성 탭을 표시합니다.
+ * URL 이동이 필요없는 경우 TabBar 컴포넌트를 사용해주세요.
+ * tabClassName으로 각 탭 버튼의 너비를 외부에서 지정할 수 있습니다.
+ *
+ * @param tabs - 탭 목록 (id: 고유 식별자, label: 탭 이름, href: 이동할 URL)
+ * @param tabClassName - 각 탭에 추가로 적용할 클래스 이름
+ *
+ * @example
+ * ```tsx
+ * <TabNav
+ *  tabs={[
+ *    { id: 'info', label: '내 정보', href: '/mypage/info' },
+ *    { id: 'reservation-list', label: '예약내역', href: '/mypage/reservations' },
+ *    { id: 'activity', label: '내 체험 관리', href: '/mypage/activities' },
+ *    { id: 'reservation-status', label: '예약 현황', href: '/mypage/reservation-status' },
+ *  ]}
+ *  tabClassName="flex-1"
+ * />
+ * ```
+ */
+export default function TabNav({ tabs, tabClassName }: TabNavProps) {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex w-full border-b border-gray-100" role="tablist" aria-label="탭 목록">
+      {tabs.map((tab) => {
+        const isActive = pathname === tab.href;
+        return (
+          <Link
+            key={tab.id}
+            href={tab.href}
+            role="tab"
+            aria-selected={isActive}
+            className={cn(tabVariants({ state: isActive ? 'active' : 'inactive' }), tabClassName)}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/shared/ui/tab-bar/TabNav.tsx
+++ b/src/shared/ui/tab-bar/TabNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { tabVariants } from '@/shared/ui/tab-bar/styles/tabVariants';
 import { handleTabKeyDown } from '@/shared/ui/tab-bar/utils/tabKeyboardNavigation';
 import { cn } from '@/shared/utils/cn';
@@ -37,7 +37,6 @@ type TabNavProps = {
  */
 export default function TabNav({ tabs, tabClassName }: TabNavProps) {
   const pathname = usePathname();
-  const router = useRouter();
 
   return (
     <div className="flex w-full border-b border-gray-100" role="tablist" aria-label="탭 목록">
@@ -50,11 +49,7 @@ export default function TabNav({ tabs, tabClassName }: TabNavProps) {
             role="tab"
             aria-selected={isActive}
             className={cn(tabVariants({ state: isActive ? 'active' : 'inactive' }), tabClassName)}
-            onKeyDown={(e) =>
-              handleTabKeyDown(e, tabs.length, index, (nextIndex) => {
-                router.push(tabs[nextIndex].href);
-              })
-            }
+            onKeyDown={(e) => handleTabKeyDown(e, tabs.length, index, () => {})}
           >
             {tab.label}
           </Link>

--- a/src/shared/ui/tab-bar/TabNav.tsx
+++ b/src/shared/ui/tab-bar/TabNav.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { tabVariants } from '@/shared/ui/tab-bar/styles/tabVariants';
+import { handleTabKeyDown } from '@/shared/ui/tab-bar/utils/tabKeyboardNavigation';
 import { cn } from '@/shared/utils/cn';
 
 type Tab = {
@@ -36,10 +37,11 @@ type TabNavProps = {
  */
 export default function TabNav({ tabs, tabClassName }: TabNavProps) {
   const pathname = usePathname();
+  const router = useRouter();
 
   return (
     <div className="flex w-full border-b border-gray-100" role="tablist" aria-label="탭 목록">
-      {tabs.map((tab) => {
+      {tabs.map((tab, index) => {
         const isActive = pathname === tab.href;
         return (
           <Link
@@ -48,6 +50,11 @@ export default function TabNav({ tabs, tabClassName }: TabNavProps) {
             role="tab"
             aria-selected={isActive}
             className={cn(tabVariants({ state: isActive ? 'active' : 'inactive' }), tabClassName)}
+            onKeyDown={(e) =>
+              handleTabKeyDown(e, tabs.length, index, (nextIndex) => {
+                router.push(tabs[nextIndex].href);
+              })
+            }
           >
             {tab.label}
           </Link>

--- a/src/shared/ui/tab-bar/styles/tabVariants.ts
+++ b/src/shared/ui/tab-bar/styles/tabVariants.ts
@@ -1,0 +1,13 @@
+import { cva } from 'class-variance-authority';
+
+export const tabVariants = cva(
+  'h-10 cursor-pointer flex items-center justify-center -mb-px', // 모든 탭에 공통으로 적용될 스타일
+  {
+    variants: {
+      state: {
+        active: 'typo-16-bold text-primary-500 border-b-2 border-primary-500', // 활성화 탭
+        inactive: 'typo-16-medium text-gray-500 hover:text-gray-700 border-b-2 border-transparent', // 비활성화 탭
+      },
+    },
+  }
+);

--- a/src/shared/ui/tab-bar/utils/tabKeyboardNavigation.ts
+++ b/src/shared/ui/tab-bar/utils/tabKeyboardNavigation.ts
@@ -1,0 +1,29 @@
+import type { KeyboardEvent } from 'react';
+
+export const handleTabKeyDown = (
+  e: KeyboardEvent<HTMLElement>,
+  tabsLength: number,
+  currentIndex: number,
+  onChange: (index: number) => void
+) => {
+  let nextIndex: number | null = null;
+
+  // 오른쪽 화살표 키를 누르면 다음 탭으로 이동
+  if (e.key === 'ArrowRight') {
+    e.preventDefault();
+    nextIndex = (currentIndex + 1) % tabsLength;
+  }
+  // 왼쪽 화살표 키를 누르면 이전 탭으로 이동
+  if (e.key === 'ArrowLeft') {
+    e.preventDefault();
+    nextIndex = (currentIndex - 1 + tabsLength) % tabsLength;
+  }
+
+  if (nextIndex !== null) {
+    onChange(nextIndex);
+    // 이동된 탭으로 포커스 이동
+    const tablist = e.currentTarget.closest('[role="tablist"]');
+    const tabs = tablist?.querySelectorAll('[role="tab"]');
+    (tabs?.[nextIndex] as HTMLElement)?.focus();
+  }
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #57 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
* TabBar 공통 컴포넌트를 구현했습니다.
* Storybook 스토리를 추가하여 3가지 케이스 UI 테스트 완료했습니다.

주요 구현 사항
* cva로 활성화/비활성화 탭 스타일을 관리합니다.
* count prop으로 상태별 체험 개수를 선택적으로 표시할 수 있습니다.
* tabClassName으로 각 탭 버튼의 너비를 외부에서 지정할 수 있습니다.
* 체험 상세 페이지 탭은 PC/태블릿에서 왼쪽 정렬, 모바일에서는 균등 분배되도록 구현했습니다. (외에는 모두 균등 분배)


### 스크린샷 (선택)
<img width="1083" height="770" alt="image" src="https://github.com/user-attachments/assets/e8649f69-97d2-417f-8e6f-44f4f770a7d7" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
