### PR TITLE
[✨ Feat/#74] 공통 Header 컴포넌트 구현

### DIFF
--- a/src/shared/hooks/useScroll.ts
+++ b/src/shared/hooks/useScroll.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * useScroll 옵션입니다.
+ */
+export type UseScrollOptions = {
+  /**
+   * scroll 이벤트 구독 여부입니다.
+   *
+   * @remarks
+   * - `/` 같은 특정 페이지에서만 동작시키고 싶을 때 사용합니다.
+   */
+  isEnabled?: boolean;
+
+  /**
+   * `isScrolled` 판정 기준(scrollY 임계값)입니다.
+   *
+   * @default 0
+   */
+  threshold?: number;
+};
+
+/**
+ * useScroll
+ *
+ * 스크롤 상태를 구독하는 공통 훅입니다.
+ *
+ * @remarks
+ * - `scroll` 이벤트는 매우 자주 발생하므로 `requestAnimationFrame` 기반으로 쓰로틀링합니다.
+ * - `isScrolled`(임계값 초과 여부)가 바뀔 때만 state를 갱신해 불필요한 re-render를 줄입니다.
+ * - SSR 환경에서는 `window`가 없으므로 아무 것도 구독하지 않고 초기값(false)만 반환합니다.
+ *
+ * @param options.isEnabled - 스크롤 구독 활성화 여부
+ * @param options.threshold - `isScrolled` 판정 임계값 (scrollY > threshold)
+ * @returns `isScrolled` - 스크롤이 임계값을 초과했는지 여부
+ */
+const useScroll = ({ isEnabled = true, threshold = 0 }: UseScrollOptions = {}) => {
+  const [isScrolled, setIsScrolled] = useState(false);
+  const isScrolledRef = useRef(false);
+  const rafIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isEnabled) {
+      // 비활성화 상태에서는 스크롤 구독을 하지 않고,
+      // `isScrolled`를 기본값(false)로 되돌립니다.
+      if (isScrolledRef.current) {
+        isScrolledRef.current = false;
+        setIsScrolled(false);
+      }
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const update = () => {
+      rafIdRef.current = null;
+
+      const nextIsScrolled = window.scrollY > threshold;
+      if (nextIsScrolled === isScrolledRef.current) {
+        return;
+      }
+
+      isScrolledRef.current = nextIsScrolled;
+      setIsScrolled(nextIsScrolled);
+    };
+
+    const onScroll = () => {
+      if (rafIdRef.current !== null) {
+        return;
+      }
+      rafIdRef.current = window.requestAnimationFrame(update);
+    };
+
+    // 초기 상태 동기화
+    update();
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (rafIdRef.current !== null) {
+        window.cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, [isEnabled, threshold]);
+
+  return { isScrolled };
+};
+
+export default useScroll;

--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -2,3 +2,4 @@
 @import './fonts.css';
 @import './colors.css';
 @import './scroll.css';
+@import './layout.css';

--- a/src/shared/styles/layout.css
+++ b/src/shared/styles/layout.css
@@ -1,0 +1,3 @@
+@utility shell-inner {
+  @apply mx-auto flex h-full w-full max-w-380 items-center justify-between px-6 md:px-7.5 xl:px-50;
+}

--- a/src/shared/ui/dropdown/action/ActionDropdown.stories.tsx
+++ b/src/shared/ui/dropdown/action/ActionDropdown.stories.tsx
@@ -8,7 +8,7 @@ import {
   ActionDropdownContent,
   ActionDropdownItem,
 } from '@/shared/ui/dropdown/action';
-import Profile from '@/shared/ui/profile/Profile';
+import Profile from '@/shared/ui/header/profile/Profile';
 
 /**
  * ActionDropdown 컴포넌트 스토리 가이드

--- a/src/shared/ui/header/GuestNav.tsx
+++ b/src/shared/ui/header/GuestNav.tsx
@@ -1,8 +1,7 @@
 import { cva } from 'class-variance-authority';
 import Link from 'next/link';
+import type { HeaderTheme } from '@/shared/ui/header/types';
 import { cn } from '@/shared/utils/cn';
-
-type HeaderTheme = 'primary' | 'light';
 
 const authLinkVariants = cva('typo-14-medium rounded-md px-3 py-2 transition-colors', {
   variants: {

--- a/src/shared/ui/header/GuestNav.tsx
+++ b/src/shared/ui/header/GuestNav.tsx
@@ -36,7 +36,7 @@ type GuestNavProps = {
  */
 export default function GuestNav({ theme, className }: GuestNavProps) {
   return (
-    <nav aria-label="인증 메뉴" className={cn('flex items-center gap-5', className)}>
+    <nav aria-label="인증 메뉴" className={cn('flex items-center gap-1', className)}>
       <Link href="/login" className={authLinkVariants({ theme })}>
         로그인
       </Link>

--- a/src/shared/ui/header/GuestNav.tsx
+++ b/src/shared/ui/header/GuestNav.tsx
@@ -1,0 +1,49 @@
+import { cva } from 'class-variance-authority';
+import Link from 'next/link';
+import { cn } from '@/shared/utils/cn';
+
+type HeaderTheme = 'primary' | 'light';
+
+const authLinkVariants = cva('typo-14-medium rounded-md px-3 py-2 transition-colors', {
+  variants: {
+    theme: {
+      primary: 'text-white hover:bg-primary-600',
+      light: 'text-gray-950 hover:bg-primary-100',
+    },
+  },
+  defaultVariants: {
+    theme: 'light',
+  },
+});
+
+/**
+ * GuestNav 컴포넌트 Props 입니다.
+ *
+ * @property theme - 헤더 테마 (`'primary' | 'light'`)
+ * @property className - wrapper에 추가할 클래스
+ */
+type GuestNavProps = {
+  theme: HeaderTheme;
+  className?: string;
+};
+
+/**
+ * ## GuestNav
+ *
+ * 비로그인 상태에서 사용하는 헤더 우측 메뉴(로그인/회원가입 링크) 컴포넌트입니다.
+ *
+ * @param props.theme - 헤더 테마
+ * @param props.className - 추가 클래스
+ */
+export default function GuestNav({ theme, className }: GuestNavProps) {
+  return (
+    <nav aria-label="인증 메뉴" className={cn('flex items-center gap-5', className)}>
+      <Link href="/login" className={authLinkVariants({ theme })}>
+        로그인
+      </Link>
+      <Link href="/signup" className={authLinkVariants({ theme })}>
+        회원가입
+      </Link>
+    </nav>
+  );
+}

--- a/src/shared/ui/header/Header.stories.tsx
+++ b/src/shared/ui/header/Header.stories.tsx
@@ -111,9 +111,13 @@ export const HomeScrolled: Story = {
     const win = canvasElement.ownerDocument.defaultView;
     if (!win) return;
 
-    await new Promise((r) => win.setTimeout(r, 0));
     win.scrollTo(0, SCROLL_Y);
     win.dispatchEvent(new Event('scroll'));
+
+    // rAF 쓰로틀이므로 한 프레임 대기
+    await new Promise<void>((resolve) => {
+      win.requestAnimationFrame(() => resolve());
+    });
   },
 };
 

--- a/src/shared/ui/header/Header.stories.tsx
+++ b/src/shared/ui/header/Header.stories.tsx
@@ -1,0 +1,139 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/nextjs';
+import { createNavigation, usePathname } from '@storybook/nextjs/navigation.mock';
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import Header from '@/shared/ui/header/Header';
+
+const SCROLL_Y = 200;
+
+const ScrollResetter = ({ children }: { children: ReactNode }) => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  return children;
+};
+
+const withScrollReset: Decorator = (Story) => (
+  <ScrollResetter>
+    <Story />
+  </ScrollResetter>
+);
+
+const meta: Meta<typeof Header> = {
+  title: 'Shared/Header',
+  component: Header,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [withScrollReset],
+  argTypes: {
+    isLoggedIn: {
+      control: 'boolean',
+    },
+    className: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const PageScaffold = ({ children }: { children: ReactNode }) => {
+  return (
+    <div className="min-h-[200vh] bg-gray-50">
+      {children}
+      <main className="mx-auto w-full max-w-380 px-6 py-10 md:px-7.5 xl:px-50">
+        <div className="space-y-4">
+          <div className="h-40 rounded-lg bg-white" />
+          <div className="h-40 rounded-lg bg-white" />
+          <div className="h-40 rounded-lg bg-white" />
+          <div className="h-40 rounded-lg bg-white" />
+          <div className="h-40 rounded-lg bg-white" />
+        </div>
+      </main>
+    </div>
+  );
+};
+
+const withPageScaffold: Decorator = (Story) => (
+  <PageScaffold>
+    <Story />
+  </PageScaffold>
+);
+
+const withPathname = (pathname: string): Decorator => {
+  const withPathnameDecorator: Decorator = (Story) => {
+    // next/navigation mock 초기화 (useRouter 내부에서 필요)
+    createNavigation({});
+    usePathname.mockReturnValue(pathname);
+    return <Story />;
+  };
+
+  return withPathnameDecorator;
+};
+
+export const HomeGuest: Story = {
+  name: '/ (Guest)',
+  args: {
+    isLoggedIn: false,
+  },
+  decorators: [withPageScaffold, withPathname('/')],
+};
+
+export const HomeLoggedIn: Story = {
+  name: '/ (Logged In)',
+  args: {
+    isLoggedIn: true,
+    user: {
+      nickname: '정만철',
+      profileImageUrl:
+        'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSgGVm5P0-8Mjkm597XaYeSL2BlMIwp-APf0Q&s',
+    },
+  },
+  decorators: [withPageScaffold, withPathname('/')],
+};
+
+export const HomeScrolled: Story = {
+  name: '/ (Scrolled)',
+  args: {
+    isLoggedIn: true,
+    user: {
+      nickname: '정만철',
+      profileImageUrl:
+        'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSgGVm5P0-8Mjkm597XaYeSL2BlMIwp-APf0Q&s',
+    },
+  },
+  decorators: [withPageScaffold, withPathname('/')],
+  play: async ({ canvasElement }) => {
+    const win = canvasElement.ownerDocument.defaultView;
+    if (!win) return;
+
+    await new Promise((r) => win.setTimeout(r, 0));
+    win.scrollTo(0, SCROLL_Y);
+    win.dispatchEvent(new Event('scroll'));
+  },
+};
+
+export const ActivitiesGuest: Story = {
+  name: '/activities (Guest)',
+  args: {
+    isLoggedIn: false,
+  },
+  decorators: [withPageScaffold, withPathname('/activities')],
+};
+
+export const ActivitiesLoggedIn: Story = {
+  name: '/activities (Logged In)',
+  args: {
+    isLoggedIn: true,
+    user: {
+      nickname: '정만철',
+      profileImageUrl:
+        'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSgGVm5P0-8Mjkm597XaYeSL2BlMIwp-APf0Q&s',
+    },
+  },
+  decorators: [withPageScaffold, withPathname('/activities')],
+};

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -2,6 +2,7 @@
 
 import { cva } from 'class-variance-authority';
 import { usePathname } from 'next/navigation';
+import useScroll from '@/shared/hooks/useScroll';
 import type { AvatarUser } from '@/shared/ui/avatar/types';
 import HeaderNav from '@/shared/ui/header/HeaderNav';
 import type { HeaderTheme } from '@/shared/ui/header/types';
@@ -58,7 +59,9 @@ type HeaderProps = {
  */
 export default function Header({ isLoggedIn = false, user, className }: HeaderProps) {
   const pathname = usePathname();
-  const theme: HeaderTheme = pathname === '/' ? 'primary' : 'light';
+  const { isScrolled } = useScroll({ isEnabled: pathname === '/' });
+
+  const theme: HeaderTheme = pathname === '/' && !isScrolled ? 'primary' : 'light';
 
   return (
     <header className={cn('sticky top-0 z-50', headerVariants({ theme }), className)}>

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -2,6 +2,7 @@
 
 import { cva } from 'class-variance-authority';
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import type { AvatarUser } from '@/shared/ui/avatar/types';
 import HeaderNav from '@/shared/ui/header/HeaderNav';
 import Logo from '@/shared/ui/logo/Logo';
@@ -59,7 +60,21 @@ type HeaderProps = {
  */
 export default function Header({ isLoggedIn = false, user, className }: HeaderProps) {
   const pathname = usePathname();
-  const theme: HeaderTheme = pathname === '/' ? 'primary' : 'light';
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    if (pathname !== '/') {
+      return;
+    }
+
+    const update = () => setIsScrolled(window.scrollY > 0);
+    update();
+
+    window.addEventListener('scroll', update, { passive: true });
+    return () => window.removeEventListener('scroll', update);
+  }, [pathname]);
+
+  const theme: HeaderTheme = pathname === '/' && !isScrolled ? 'primary' : 'light';
 
   return (
     <header className={cn('sticky top-0 z-50', headerVariants({ theme }), className)}>

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -12,7 +12,7 @@ const headerVariants = cva('h-12 md:h-20', {
   variants: {
     theme: {
       primary: 'bg-primary-500',
-      light: 'border-gray-100 bg-white/60 backdrop-blur',
+      light: 'bg-white/60 backdrop-blur',
     },
   },
   defaultVariants: {

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -2,13 +2,11 @@
 
 import { cva } from 'class-variance-authority';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
 import type { AvatarUser } from '@/shared/ui/avatar/types';
 import HeaderNav from '@/shared/ui/header/HeaderNav';
+import type { HeaderTheme } from '@/shared/ui/header/types';
 import Logo from '@/shared/ui/logo/Logo';
 import { cn } from '@/shared/utils/cn';
-
-type HeaderTheme = 'primary' | 'light';
 
 const headerVariants = cva('h-12 md:h-20', {
   variants: {
@@ -60,21 +58,7 @@ type HeaderProps = {
  */
 export default function Header({ isLoggedIn = false, user, className }: HeaderProps) {
   const pathname = usePathname();
-  const [isScrolled, setIsScrolled] = useState(false);
-
-  useEffect(() => {
-    if (pathname !== '/') {
-      return;
-    }
-
-    const update = () => setIsScrolled(window.scrollY > 0);
-    update();
-
-    window.addEventListener('scroll', update, { passive: true });
-    return () => window.removeEventListener('scroll', update);
-  }, [pathname]);
-
-  const theme: HeaderTheme = pathname === '/' && !isScrolled ? 'primary' : 'light';
+  const theme: HeaderTheme = pathname === '/' ? 'primary' : 'light';
 
   return (
     <header className={cn('sticky top-0 z-50', headerVariants({ theme }), className)}>

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -53,6 +53,18 @@ type HeaderProps = {
  * - `/` 경로에서는 primary 테마, 그 외는 light 테마 스타일을 적용합니다.
  * - 우측 영역은 `HeaderNav`에서 `isLoggedIn`/`user`로 분기합니다.
  *
+ * @example
+ * ```tsx
+ * // Guest
+ * <Header />
+ *
+ * // Logged in
+ * <Header
+ *   isLoggedIn
+ *   user={{ nickname: '정만철', profileImageUrl: 'https://...' }}
+ * />
+ * ```
+ *
  * @param props.isLoggedIn - 로그인 여부
  * @param props.user - 유저 정보
  * @param props.className - 추가 클래스

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -72,13 +72,14 @@ export default function Header({ isLoggedIn = false, user, className }: HeaderPr
   const { isScrolled } = useScroll({ isEnabled: isScrollThemedPage });
 
   const theme: HeaderTheme = isScrollThemedPage && !isScrolled ? 'primary' : 'light';
+  const LogoWrapper = pathname === '/' || pathname === '/search' ? 'h1' : 'div';
 
   return (
     <header className={cn('sticky top-0 z-50', headerVariants({ theme }), className)}>
       <div className="shell-inner">
-        <h1 className="leading-none">
+        <LogoWrapper className="leading-none">
           <Logo variant={logoVariantByTheme[theme]} className="h-6 md:h-7" />
-        </h1>
+        </LogoWrapper>
 
         <HeaderNav theme={theme} isLoggedIn={isLoggedIn} user={user} />
       </div>

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -21,10 +21,6 @@ const headerVariants = cva('h-12 md:h-20', {
   },
 });
 
-const headerInnerVariants = cva(
-  'mx-auto flex h-full w-full max-w-380 items-center justify-between px-6 md:px-7.5 xl:px-50'
-);
-
 const logoVariantByTheme = {
   primary: 'white',
   light: 'default',
@@ -77,7 +73,7 @@ export default function Header({ isLoggedIn = false, user, className }: HeaderPr
 
   return (
     <header className={cn('sticky top-0 z-50', headerVariants({ theme }), className)}>
-      <div className={headerInnerVariants()}>
+      <div className="shell-inner">
         <h1 className="leading-none">
           <Logo variant={logoVariantByTheme[theme]} className="h-6 md:h-7" />
         </h1>

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { cva } from 'class-variance-authority';
+import { usePathname } from 'next/navigation';
+import type { AvatarUser } from '@/shared/ui/avatar/types';
+import HeaderNav from '@/shared/ui/header/HeaderNav';
+import Logo from '@/shared/ui/logo/Logo';
+import { cn } from '@/shared/utils/cn';
+
+type HeaderTheme = 'primary' | 'light';
+
+const headerVariants = cva('h-12 md:h-20', {
+  variants: {
+    theme: {
+      primary: 'bg-primary-500',
+      light: 'border-gray-100 bg-white/60 backdrop-blur',
+    },
+  },
+  defaultVariants: {
+    theme: 'light',
+  },
+});
+
+const headerInnerVariants = cva(
+  'mx-auto flex h-full w-full max-w-380 items-center justify-between px-6 md:px-7.5 xl:px-50'
+);
+
+const logoVariantByTheme = {
+  primary: 'white',
+  light: 'default',
+} as const;
+
+/**
+ * Header 컴포넌트 Props 입니다.
+ *
+ * @property isLoggedIn - 로그인 여부 (로그인 상태 + user 유무로 우측 메뉴가 결정됩니다)
+ * @property user - 로그인 유저 정보
+ * @property className - 헤더 wrapper에 추가할 클래스
+ */
+type HeaderProps = {
+  isLoggedIn?: boolean;
+  user?: AvatarUser;
+  className?: string;
+};
+
+/**
+ * ## Header
+ *
+ * 앱 상단 헤더 컴포넌트입니다.
+ *
+ * @remarks
+ * - 모바일 높이 `48px`, `md`부터 `80px`입니다.
+ * - `/` 경로에서는 primary 테마, 그 외는 light 테마 스타일을 적용합니다.
+ * - 우측 영역은 `HeaderNav`에서 `isLoggedIn`/`user`로 분기합니다.
+ *
+ * @param props.isLoggedIn - 로그인 여부
+ * @param props.user - 유저 정보
+ * @param props.className - 추가 클래스
+ */
+export default function Header({ isLoggedIn = false, user, className }: HeaderProps) {
+  const pathname = usePathname();
+  const theme: HeaderTheme = pathname === '/' ? 'primary' : 'light';
+
+  return (
+    <header className={cn('sticky top-0 z-50', headerVariants({ theme }), className)}>
+      <div className={headerInnerVariants()}>
+        <h1 className="leading-none">
+          <Logo variant={logoVariantByTheme[theme]} className="h-6 md:h-7" />
+        </h1>
+
+        <HeaderNav theme={theme} isLoggedIn={isLoggedIn} user={user} />
+      </div>
+    </header>
+  );
+}

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -46,7 +46,8 @@ type HeaderProps = {
  *
  * @remarks
  * - 모바일 높이 `48px`, `md`부터 `80px`입니다.
- * - `/` 경로에서는 primary 테마, 그 외는 light 테마 스타일을 적용합니다.
+ * - `/`, `/search` 경로에서는 스크롤 위치에 따라 primary/light 테마가 전환됩니다.
+ * - 그 외 경로에서는 light 테마 스타일을 적용합니다.
  * - 우측 영역은 `HeaderNav`에서 `isLoggedIn`/`user`로 분기합니다.
  *
  * @example
@@ -67,9 +68,10 @@ type HeaderProps = {
  */
 export default function Header({ isLoggedIn = false, user, className }: HeaderProps) {
   const pathname = usePathname();
-  const { isScrolled } = useScroll({ isEnabled: pathname === '/' });
+  const isScrollThemedPage = pathname === '/' || pathname === '/search';
+  const { isScrolled } = useScroll({ isEnabled: isScrollThemedPage });
 
-  const theme: HeaderTheme = pathname === '/' && !isScrolled ? 'primary' : 'light';
+  const theme: HeaderTheme = isScrollThemedPage && !isScrolled ? 'primary' : 'light';
 
   return (
     <header className={cn('sticky top-0 z-50', headerVariants({ theme }), className)}>

--- a/src/shared/ui/header/HeaderNav.tsx
+++ b/src/shared/ui/header/HeaderNav.tsx
@@ -1,8 +1,7 @@
 import type { AvatarUser } from '@/shared/ui/avatar/types';
 import GuestNav from '@/shared/ui/header/GuestNav';
+import type { HeaderTheme } from '@/shared/ui/header/types';
 import UserNav from '@/shared/ui/header/UserNav';
-
-type HeaderTheme = 'primary' | 'light';
 
 /**
  * HeaderNav 컴포넌트 Props 입니다.

--- a/src/shared/ui/header/HeaderNav.tsx
+++ b/src/shared/ui/header/HeaderNav.tsx
@@ -1,0 +1,56 @@
+import type { AvatarUser } from '@/shared/ui/avatar/types';
+import GuestNav from '@/shared/ui/header/GuestNav';
+import UserNav from '@/shared/ui/header/UserNav';
+
+type HeaderTheme = 'primary' | 'light';
+
+/**
+ * HeaderNav 컴포넌트 Props 입니다.
+ *
+ * @property theme - 헤더 테마 (`'primary' | 'light'`)
+ * @property isLoggedIn - 로그인 여부
+ * @property user - 로그인 유저 정보
+ */
+type HeaderNavProps = {
+  theme: HeaderTheme;
+  isLoggedIn?: boolean;
+  user?: AvatarUser;
+};
+
+type LoggedInActionsProps = {
+  theme: HeaderTheme;
+  user: AvatarUser;
+};
+
+function LoggedInActions({ theme, user }: LoggedInActionsProps) {
+  return <UserNav theme={theme} user={user} />;
+}
+
+type GuestActionsProps = {
+  theme: HeaderTheme;
+};
+
+function GuestActions({ theme }: GuestActionsProps) {
+  return <GuestNav theme={theme} />;
+}
+
+/**
+ * ## HeaderNav
+ *
+ * 헤더 우측 영역(유저 메뉴/게스트 메뉴)을 렌더링하는 컴포넌트입니다.
+ *
+ * @remarks
+ * - `isLoggedIn && user`이면 `UserNav`를 렌더링합니다.
+ * - 그 외에는 `GuestNav`를 렌더링합니다.
+ *
+ * @param props.theme - 헤더 테마
+ * @param props.isLoggedIn - 로그인 여부
+ * @param props.user - 유저 정보
+ */
+export default function HeaderNav({ theme, isLoggedIn = false, user }: HeaderNavProps) {
+  if (isLoggedIn && user) {
+    return <LoggedInActions theme={theme} user={user} />;
+  }
+
+  return <GuestActions theme={theme} />;
+}

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -77,7 +77,7 @@ export default function UserNav({ theme, user, className, onLogout }: UserNavPro
       <button
         type="button"
         aria-label="알림"
-        className="flex h-10 w-10 cursor-pointer items-center justify-center"
+        className="flex h-6 w-6 cursor-pointer items-center justify-center"
       >
         <NotificationIcon aria-hidden="true" className={notificationIconVariants({ theme })} />
       </button>

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -9,9 +9,8 @@ import {
   ActionDropdownTrigger,
 } from '@/shared/ui/dropdown/action';
 import Profile from '@/shared/ui/header/profile/Profile';
+import type { HeaderTheme } from '@/shared/ui/header/types';
 import { cn } from '@/shared/utils/cn';
-
-type HeaderTheme = 'primary' | 'light';
 
 const notificationIconVariants = cva('h-6 w-6', {
   variants: {

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -69,6 +69,7 @@ type UserNavProps = {
  */
 export default function UserNav({ theme, user, className, onLogout }: UserNavProps) {
   const router = useRouter();
+  // TODO: 실제 로그아웃 로직(인증 상태/토큰/스토어 초기화 등) 연결
   const handleLogout = onLogout ?? (() => {});
 
   return (

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -77,7 +77,7 @@ export default function UserNav({ theme, user, className, onLogout }: UserNavPro
       <button
         type="button"
         aria-label="알림"
-        className="flex h-10 w-10 items-center justify-center"
+        className="flex h-10 w-10 cursor-pointer items-center justify-center"
       >
         <NotificationIcon aria-hidden="true" className={notificationIconVariants({ theme })} />
       </button>
@@ -85,7 +85,10 @@ export default function UserNav({ theme, user, className, onLogout }: UserNavPro
       <span aria-hidden="true" className={dividerVariants()} />
 
       <ActionDropdown>
-        <ActionDropdownTrigger className="flex items-center" ariaLabel="유저 메뉴 열기">
+        <ActionDropdownTrigger
+          className="flex cursor-pointer items-center"
+          ariaLabel="유저 메뉴 열기"
+        >
           <Profile user={user} size="sm" nicknameClassName={profileNicknameVariants({ theme })} />
         </ActionDropdownTrigger>
 

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -1,0 +1,100 @@
+import { cva } from 'class-variance-authority';
+import { useRouter } from 'next/navigation';
+import { NotificationIcon } from '@/shared/assets/icons';
+import type { AvatarUser } from '@/shared/ui/avatar/types';
+import {
+  ActionDropdown,
+  ActionDropdownContent,
+  ActionDropdownItem,
+  ActionDropdownTrigger,
+} from '@/shared/ui/dropdown/action';
+import Profile from '@/shared/ui/header/profile/Profile';
+import { cn } from '@/shared/utils/cn';
+
+type HeaderTheme = 'primary' | 'light';
+
+const notificationIconVariants = cva('h-6 w-6', {
+  variants: {
+    theme: {
+      primary: '[&>path]:fill-white',
+      light: '',
+    },
+  },
+  defaultVariants: {
+    theme: 'light',
+  },
+});
+
+const dividerVariants = cva('h-3.5 w-px bg-gray-100');
+
+const profileNicknameVariants = cva('', {
+  variants: {
+    theme: {
+      primary: 'text-white',
+      light: '',
+    },
+  },
+  defaultVariants: {
+    theme: 'light',
+  },
+});
+
+/**
+ * UserNav 컴포넌트 Props 입니다.
+ *
+ * @property theme - 헤더 테마 (`'primary' | 'light'`)
+ * @property user - 유저 정보
+ * @property className - wrapper에 추가할 클래스
+ * @property onLogout - 로그아웃 클릭 시 실행할 콜백
+ */
+type UserNavProps = {
+  theme: HeaderTheme;
+  user: AvatarUser;
+  className?: string;
+  onLogout?: () => void;
+};
+
+/**
+ * ## UserNav
+ *
+ * 로그인 상태에서 사용하는 헤더 우측 메뉴 컴포넌트입니다.
+ *
+ * @remarks
+ * - 알림 버튼과 프로필 드롭다운(마이페이지/로그아웃)을 제공합니다.
+ * - 드롭다운은 `ActionDropdown` 기반으로 동작합니다.
+ *
+ * @param props.theme - 헤더 테마
+ * @param props.user - 유저 정보
+ * @param props.className - 추가 클래스
+ * @param props.onLogout - 로그아웃 콜백
+ */
+export default function UserNav({ theme, user, className, onLogout }: UserNavProps) {
+  const router = useRouter();
+  const handleLogout = onLogout ?? (() => {});
+
+  return (
+    <div className={cn('flex items-center gap-5', className)}>
+      {/* TODO: 알림 구현 */}
+      <button
+        type="button"
+        aria-label="알림"
+        className="flex h-10 w-10 items-center justify-center"
+      >
+        <NotificationIcon aria-hidden="true" className={notificationIconVariants({ theme })} />
+      </button>
+
+      <span aria-hidden="true" className={dividerVariants()} />
+
+      <ActionDropdown>
+        <ActionDropdownTrigger className="flex items-center" ariaLabel="유저 메뉴 열기">
+          <Profile user={user} size="sm" nicknameClassName={profileNicknameVariants({ theme })} />
+        </ActionDropdownTrigger>
+
+        <ActionDropdownContent className="right-0 left-auto">
+          <ActionDropdownItem onClick={() => router.push('/mypage')}>마이페이지</ActionDropdownItem>
+          <ActionDropdownItem onClick={handleLogout}>로그아웃</ActionDropdownItem>
+        </ActionDropdownContent>
+      </ActionDropdown>
+    </div>
+  );
+}

--- a/src/shared/ui/header/profile/Profile.stories.tsx
+++ b/src/shared/ui/header/profile/Profile.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
-import Profile from '@/shared/ui/profile/Profile';
+import Profile from '@/shared/ui/header/profile/Profile';
 
 const meta: Meta<typeof Profile> = {
   title: 'Shared/Profile',

--- a/src/shared/ui/header/profile/Profile.tsx
+++ b/src/shared/ui/header/profile/Profile.tsx
@@ -7,8 +7,14 @@ type ProfileProps = Omit<AvatarProps, 'children'> & {
 };
 
 /**
+ * ## Profile
+ *
  * 아바타 + 닉네임 조합으로 된 프로필 컴포넌트입니다.
  * 닉네임 색상은 검정(text-gray-950)이 기본 값입니다.
+ *
+ * @param props.user - 아바타에 표시할 유저 정보
+ * @param props.size - 아바타 사이즈
+ * @param props.nicknameClassName - 닉네임에 적용할 추가 클래스
  *
  * @example
  * // 기본 컴포넌트
@@ -27,7 +33,7 @@ export default function Profile({
   return (
     <div className="flex items-center gap-2.5">
       <Avatar user={user} size={size}>
-        <Avatar.Img />
+        <Avatar.Img loading="eager" />
         <Avatar.Fallback />
       </Avatar>
       <span className={cn('typo-14-medium', nicknameClassName)}>{user?.nickname ?? '사용자'}</span>

--- a/src/shared/ui/header/types.ts
+++ b/src/shared/ui/header/types.ts
@@ -1,0 +1,6 @@
+/**
+ * Header 관련 공통 타입 모음입니다.
+ */
+
+/** 헤더 테마 타입 (`/` = primary, 그 외 = light) */
+export type HeaderTheme = 'primary' | 'light';

--- a/src/shared/ui/logo/Logo.tsx
+++ b/src/shared/ui/logo/Logo.tsx
@@ -30,8 +30,8 @@ const logoVariantClassName = {
 export default function Logo({ variant = 'default', className }: LogoProps) {
   return (
     <Link href="/" aria-label="Bookscape 메인 페이지로 이동">
-      <div className={cn(logoVariantClassName[variant], className)}>
-        <LogoIcon />
+      <div className={cn('inline-block', logoVariantClassName[variant], className)}>
+        <LogoIcon aria-hidden="true" className="h-full w-auto" />
       </div>
     </Link>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #74 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📝작업 내용

### Header.tsx
- 메인(`/`)에서 스크롤에 따라 헤더 테마가 `primary → light`로 전환되도록 구현했습니다
  - `/` 경로: `primary`& 스크롤 시 `light`
  - 그 외 경로: 항상 `light`
  - light의 경우 white에 불투명도를 주었고 blur처리로 자연스럽게 뒤의 내용이 비치도록 했습니당

### HeaderNav.tsx
- 헤더 우측 영역을 로그인 상태에 따라 분기 렌더링합니다.
  - `isLoggedIn && user`이면 `UserNav` 렌더
  - 그 외에는 `GuestNav` 렌더
- `theme(primary | light)`를 하위 네비게이션 컴포넌트에 전달하여 동일한 기준으로 스타일이 적용되게 유지합니다.

### UserNav.tsx
- 로그인 상태에서 보이는 우측 액션 영역을 구성합니다.
  - 알림 버튼(현재는 UI만 존재, `// TODO: 알림 구현` 추후 알림 기능 구현)
  - 구분선(divider)
  - 프로필 클릭 시 열리는 ActionDropdown
- ActionDropdown 메뉴 구성
  - `마이페이지` 클릭 시 `/mypage`로 이동 (`router.push`)
  - `로그아웃` 클릭 시 `onLogout` 실행

### GuestNav.tsx
- 비로그인 상태에서 보이는 우측 네비게이션을 구성합니다.
  - `/login` (로그인)
  - `/signup` (회원가입)
 - 스타일
  - 텍스트 컬러는 유지하고, hover는 배경색으로 처리
  - `primary` 테마: `text-white` + `hover:bg-primary-600`
  - `light` 테마: `text-gray-950` + `hover:bg-primary-100`

### 스크린샷 (선택)
스토리북 참고해주세요!
/ (Guest) → GuestNav 확인
/ (Logged In) → UserNav + 프로필 드롭다운 확인
/activities (Guest) → light 테마 + GuestNav 확인
/activities (Logged In) → light 테마 + UserNav 확인

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 헤더 컴포넌트 PC버전에서 패딩값이 200px인데 lg(1024px)부터 패딩값이 너무 큰거 같아서 xl로 변경해서 반응형 구현했습니다!
- 푸터랑 맞춰야할거 같아욤..