### PR TITLE
[✨Feat/#78] 공통 백버튼+타이틀+설명 컴포넌트 구현

### DIFF
--- a/src/shared/assets/icons/ic-chevron-left.svg
+++ b/src/shared/assets/icons/ic-chevron-left.svg
@@ -1,3 +1,3 @@
-<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M22.1465 14.293L16.4395 20L22.1465 25.707L23.5605 24.293L19.2675 20L23.5605 15.707L22.1465 14.293Z" fill="currentColor"/>
 </svg>

--- a/src/shared/assets/icons/ic-chevron-left.svg
+++ b/src/shared/assets/icons/ic-chevron-left.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M22.1465 14.293L16.4395 20L22.1465 25.707L23.5605 24.293L19.2675 20L23.5605 15.707L22.1465 14.293Z" fill="currentColor"/>
 </svg>

--- a/src/shared/ui/page-header/PageHeader.stories.tsx
+++ b/src/shared/ui/page-header/PageHeader.stories.tsx
@@ -1,15 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
+import { fn } from 'storybook/test';
 import PageHeader from './PageHeader';
 
 const meta: Meta<typeof PageHeader> = {
   title: 'Shared/PageHeader',
   component: PageHeader,
   tags: ['autodocs'],
-  parameters: {
-    nextjs: {
-      appDirectory: true,
-    },
-  },
 };
 
 export default meta;
@@ -19,11 +15,13 @@ export const Default: Story = {
   args: {
     title: '체험활동',
     description: '체험을 탐색하고 예약할 수 있습니다.',
+    onBack: fn(),
   },
 };
 
 export const NoDescription: Story = {
   args: {
     title: '내 체험 등록',
+    onBack: fn(),
   },
 };

--- a/src/shared/ui/page-header/PageHeader.stories.tsx
+++ b/src/shared/ui/page-header/PageHeader.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 import { fn } from 'storybook/test';
-import PageHeader from './PageHeader';
+import PageHeader from '@/shared/ui/page-header/PageHeader';
 
 const meta: Meta<typeof PageHeader> = {
   title: 'Shared/PageHeader',

--- a/src/shared/ui/page-header/PageHeader.stories.tsx
+++ b/src/shared/ui/page-header/PageHeader.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import PageHeader from './PageHeader';
+
+const meta: Meta<typeof PageHeader> = {
+  title: 'Shared/PageHeader',
+  component: PageHeader,
+  tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: '체험활동',
+    description: '체험을 탐색하고 예약할 수 있습니다.',
+  },
+};
+
+export const NoDescription: Story = {
+  args: {
+    title: '내 체험 등록',
+  },
+};

--- a/src/shared/ui/page-header/PageHeader.tsx
+++ b/src/shared/ui/page-header/PageHeader.tsx
@@ -33,7 +33,7 @@ export default function PageHeader({ title, description }: PageHeaderProps) {
     <div className="flex flex-col gap-1">
       <div className="flex items-center gap-1">
         <button onClick={() => router.back()} aria-label="이전 페이지로 이동">
-          <ChevronLeftIcon className="h-6 w-6" />
+          <ChevronLeftIcon className="h-10 w-10" />
         </button>
         <Title as="h2" size="18" weight="bold">
           {title}

--- a/src/shared/ui/page-header/PageHeader.tsx
+++ b/src/shared/ui/page-header/PageHeader.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { ChevronLeftIcon } from '@/shared/assets/icons';
+import { BackIcon } from '@/shared/assets/icons';
 import Title from '@/shared/ui/title/Title';
 
 type PageHeaderProps = {
@@ -33,13 +33,13 @@ export default function PageHeader({ title, description }: PageHeaderProps) {
     <div className="flex flex-col gap-1">
       <div className="flex items-center gap-1">
         <button onClick={() => router.back()} aria-label="이전 페이지로 이동">
-          <ChevronLeftIcon className="h-10 w-10" />
+          <BackIcon />
         </button>
         <Title as="h2" size="18" weight="bold">
           {title}
         </Title>
       </div>
-      {description && <p className="typo-14-medium text-gray-500">{description}</p>}
+      {description && <p className="pl-1.5 typo-14-medium text-gray-500">{description}</p>}
     </div>
   );
 }

--- a/src/shared/ui/page-header/PageHeader.tsx
+++ b/src/shared/ui/page-header/PageHeader.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ChevronLeftIcon } from '@/shared/assets/icons';
+import Title from '@/shared/ui/title/Title';
+
+type PageHeaderProps = {
+  title: string; // 타이틀
+  description?: string; // 설명
+};
+
+/**
+ * 페이지 상단에 백버튼과 페이지 제목, 설명을 표시하는 컴포넌트입니다.
+ *
+ * description은 선택적으로 페이지 설명을 표시할 수 있습니다.
+ * 백버튼 클릭 시 이전 페이지로 이동합니다.
+ *
+ * @param title - 페이지 제목
+ * @param description - 페이지 설명 (선택)
+ *
+ * @example
+ * ```tsx
+ * <PageHeader
+ *   title="체험활동"
+ *   description="체험을 탐색하고 예약할 수 있습니다."
+ * />
+ * ```
+ */
+export default function PageHeader({ title, description }: PageHeaderProps) {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1">
+        <button onClick={() => router.back()} aria-label="이전 페이지로 이동">
+          <ChevronLeftIcon className="h-6 w-6" />
+        </button>
+        <Title as="h2" size="18" weight="bold">
+          {title}
+        </Title>
+      </div>
+      {description && <p className="typo-14-medium text-gray-500">{description}</p>}
+    </div>
+  );
+}

--- a/src/shared/ui/page-header/PageHeader.tsx
+++ b/src/shared/ui/page-header/PageHeader.tsx
@@ -1,38 +1,45 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { BackIcon } from '@/shared/assets/icons';
 import Title from '@/shared/ui/title/Title';
 
 type PageHeaderProps = {
   title: string; // 타이틀
   description?: string; // 설명
+  onBack: () => void;
 };
 
 /**
  * 페이지 상단에 백버튼과 페이지 제목, 설명을 표시하는 컴포넌트입니다.
  *
  * description은 선택적으로 페이지 설명을 표시할 수 있습니다.
- * 백버튼 클릭 시 이전 페이지로 이동합니다.
+ * 백버튼 클릭 시 동작은 onBack prop으로 외부에서 처리합니다.
  *
  * @param title - 페이지 제목
  * @param description - 페이지 설명 (선택)
+ * @param onBack - 백버튼 클릭 시 호출되는 콜백 함수
  *
  * @example
  * ```tsx
+ * // 일반 페이지
  * <PageHeader
  *   title="체험활동"
  *   description="체험을 탐색하고 예약할 수 있습니다."
+ *   onBack={() => router.back()}
+ * />
+ *
+ * // 내 체험 등록/수정 (확인 모달 떠야할 때)
+ * <PageHeader
+ *   title="내 체험 등록"
+ *   onBack={() => setIsModalOpen(true)}
  * />
  * ```
  */
-export default function PageHeader({ title, description }: PageHeaderProps) {
-  const router = useRouter();
-
+export default function PageHeader({ title, description, onBack }: PageHeaderProps) {
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center gap-1">
-        <button onClick={() => router.back()} aria-label="이전 페이지로 이동">
+        <button onClick={onBack} aria-label="이전 페이지로 이동">
           <BackIcon />
         </button>
         <Title as="h1" size="18" weight="bold">

--- a/src/shared/ui/page-header/PageHeader.tsx
+++ b/src/shared/ui/page-header/PageHeader.tsx
@@ -4,8 +4,8 @@ import { BackIcon } from '@/shared/assets/icons';
 import Title from '@/shared/ui/title/Title';
 
 type PageHeaderProps = {
-  title: string; // 타이틀
-  description?: string; // 설명
+  title: string;
+  description?: string;
   onBack: () => void;
 };
 

--- a/src/shared/ui/page-header/PageHeader.tsx
+++ b/src/shared/ui/page-header/PageHeader.tsx
@@ -35,7 +35,7 @@ export default function PageHeader({ title, description }: PageHeaderProps) {
         <button onClick={() => router.back()} aria-label="이전 페이지로 이동">
           <BackIcon />
         </button>
-        <Title as="h2" size="18" weight="bold">
+        <Title as="h1" size="18" weight="bold">
           {title}
         </Title>
       </div>

--- a/src/shared/ui/page-header/PageHeader.tsx
+++ b/src/shared/ui/page-header/PageHeader.tsx
@@ -39,7 +39,7 @@ export default function PageHeader({ title, description, onBack }: PageHeaderPro
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center gap-1">
-        <button onClick={onBack} aria-label="이전 페이지로 이동">
+        <button type="button" onClick={onBack} aria-label="이전 페이지로 이동">
           <BackIcon />
         </button>
         <Title as="h1" size="18" weight="bold">

--- a/src/shared/ui/page-header/PageHeader.tsx
+++ b/src/shared/ui/page-header/PageHeader.tsx
@@ -39,7 +39,12 @@ export default function PageHeader({ title, description, onBack }: PageHeaderPro
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center gap-1">
-        <button type="button" onClick={onBack} aria-label="이전 페이지로 이동">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="이전 페이지로 이동"
+          className="cursor-pointer"
+        >
           <BackIcon />
         </button>
         <Title as="h1" size="18" weight="bold">


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #78 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* PageHeader 공통 컴포넌트를 구현했습니다.
* Storybook 스토리를 추가하여 2가지 케이스(설명 있음/없음) UI 테스트 완료했습니다.

주요 구현 사항
- 백버튼 클릭 시 동작을 onBack prop으로 외부에서 처리하도록 구현했습니다.
  - 일반 페이지에서는 이전 페이지로 이동하지만, 내 체험 등록/수정 페이지에서는 확인 모달 표시 후 이동하기 때문입니당.
- Title 공통 컴포넌트를 사용하여 h1 태그로 페이지 제목을 렌더링합니다.
- description prop은 선택적으로 페이지 설명을 표시할 수 있습니다.

### 스크린샷 (선택)
<img width="1050" height="512" alt="image" src="https://github.com/user-attachments/assets/562b0f53-655e-440b-b1c4-45785ce3541b" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
