### PR TITLE
[🔧 Chore/#97] serverFetch/bffFetch 함수 세팅

### DIFF
--- a/src/shared/apis/bffFetch.ts
+++ b/src/shared/apis/bffFetch.ts
@@ -5,8 +5,7 @@ import {
   QueryParams,
 } from '@/shared/apis/coreFetch';
 
-/** BFF 요청이므로 별도의 도메인 없이 상대 경로 사용 */
-const BFF_BASE_URL = '';
+const BFF_BASE_URL = '/api';
 
 /**
  * BFF(Backend For Frontend) 호출 전용 Fetch 함수

--- a/src/shared/apis/bffFetch.ts
+++ b/src/shared/apis/bffFetch.ts
@@ -1,0 +1,63 @@
+import {
+  RequestConfig,
+  coreFetch,
+  FetchRequestOptions,
+  QueryParams,
+} from '@/shared/apis/coreFetch';
+
+/** BFF 요청이므로 별도의 도메인 없이 상대 경로 사용 */
+const BFF_BASE_URL = '';
+
+/**
+ * BFF(Backend For Frontend) 호출 전용 Fetch 함수
+ * Next.js API Route(BFF)로 요청을 보냅니다.
+ * 별도의 도메인 없이 상대 경로를 사용합니다.
+ * 인증 정보(쿠키)는 브라우저에 의해 자동으로 요청 헤더에 포함됩니다.
+ *
+ * @example
+ * ```ts
+ * // GET 요청
+ * const user = await bffFetch.get<User>('/api/users', { id: userId });
+ *
+ * // POST 요청
+ * const result = await bffFetch.post<{ id: string }>('/api/posts', newPost);
+ * ```
+ */
+
+/** bffFetch 내부 공통 요청 함수 */
+const request = <T>({
+  endpoint,
+  method,
+  body,
+  query,
+  ...options
+}: RequestConfig): Promise<T | null> => {
+  return coreFetch<T>(BFF_BASE_URL, endpoint, { ...options, method }, query, body);
+};
+
+/** HTTP 메서드 유틸리티 */
+export const bffFetch = {
+  get: <T>(endpoint: string, query?: QueryParams, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'GET', query, ...options }),
+
+  post: <T>(endpoint: string, body?: unknown, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'POST', body, ...options }),
+
+  put: <T>(endpoint: string, body?: unknown, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'PUT', body, ...options }),
+
+  patch: <T>(endpoint: string, body?: unknown, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'PATCH', body, ...options }),
+
+  delete: <T>(endpoint: string, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'DELETE', ...options }),
+
+  postFormData: <T>(endpoint: string, formData: FormData, options?: FetchRequestOptions) =>
+    request<T>({
+      endpoint,
+      method: 'POST',
+      body: formData,
+      isFormData: true,
+      ...options,
+    }),
+};

--- a/src/shared/apis/bffFetch.ts
+++ b/src/shared/apis/bffFetch.ts
@@ -31,7 +31,13 @@ const request = <T>({
   query,
   ...options
 }: RequestConfig): Promise<T | null> => {
-  return coreFetch<T>(BFF_BASE_URL, endpoint, { ...options, method }, query, body);
+  return coreFetch<T>(
+    BFF_BASE_URL,
+    endpoint,
+    { ...options, method, credentials: 'include' },
+    query,
+    body
+  );
 };
 
 /** HTTP 메서드 유틸리티 */

--- a/src/shared/apis/coreFetch.ts
+++ b/src/shared/apis/coreFetch.ts
@@ -38,6 +38,13 @@ export type FetchRequestOptions = RequestInit & {
   isFormData?: boolean;
 };
 
+export type RequestConfig = {
+  endpoint: string;
+  method: RequestInit['method'];
+  body?: unknown;
+  query?: QueryParams;
+} & Omit<FetchRequestOptions, 'body'>;
+
 const buildQueryString = (query?: QueryParams): string => {
   if (!query) return '';
 

--- a/src/shared/apis/env.ts
+++ b/src/shared/apis/env.ts
@@ -3,7 +3,7 @@ export const ENV = {
   API_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL ?? '',
 
   // 서버 전용
-  SERVER_API_URL: process.env.NEXT_PUBLIC_BASE_URL ?? '',
+  SERVER_API_URL: process.env.API_URL ?? '',
 } as const;
 if (!ENV.API_BASE_URL) {
   throw new Error('NEXT_PUBLIC_BASE_URL is not defined. Please check your .env file.');

--- a/src/shared/apis/env.ts
+++ b/src/shared/apis/env.ts
@@ -1,5 +1,9 @@
 export const ENV = {
+  // 클라이언트 + 서버 공통 (외부 접근 가능한 API)
   API_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL ?? '',
+
+  // 서버 전용
+  SERVER_API_URL: process.env.NEXT_PUBLIC_BASE_URL ?? '',
 } as const;
 if (!ENV.API_BASE_URL) {
   throw new Error('NEXT_PUBLIC_BASE_URL is not defined. Please check your .env file.');

--- a/src/shared/apis/publicFetch.ts
+++ b/src/shared/apis/publicFetch.ts
@@ -1,5 +1,10 @@
-import { coreFetch, FetchRequestOptions, QueryParams, RequestConfig } from './coreFetch';
-import { ENV } from './env';
+import {
+  coreFetch,
+  FetchRequestOptions,
+  QueryParams,
+  RequestConfig,
+} from '@/shared/apis/coreFetch';
+import { ENV } from '@/shared/apis/env';
 /**
  * 토큰 없는 공개 API용 Fetch 유틸리티
  * publicFetch는 인증이 필요 없는 공개 API 요청을 위한 유틸리티 함수입니다. 이 함수는 coreFetch를 기반으로 하며, API 요청을 간편하게 수행할 수 있도록 도와줍니다.

--- a/src/shared/apis/publicFetch.ts
+++ b/src/shared/apis/publicFetch.ts
@@ -29,13 +29,6 @@ import { ENV } from '@/shared/apis/env';
 
 type BaseRequestOptions = Omit<FetchRequestOptions, 'body' | 'isFormData'>;
 
-// type RequestConfig = {
-//   endpoint: string;
-//   method: RequestInit['method'];
-//   body?: unknown;
-//   query?: QueryParams;
-// } & Omit<FetchRequestOptions, 'body'>;
-
 const request = <T>({ endpoint, method, body, query, ...options }: RequestConfig) =>
   coreFetch<T>(ENV.API_BASE_URL, endpoint, { ...options, method }, query, body);
 

--- a/src/shared/apis/publicFetch.ts
+++ b/src/shared/apis/publicFetch.ts
@@ -1,4 +1,4 @@
-import { coreFetch, FetchRequestOptions, QueryParams } from './coreFetch';
+import { coreFetch, FetchRequestOptions, QueryParams, RequestConfig } from './coreFetch';
 import { ENV } from './env';
 /**
  * 토큰 없는 공개 API용 Fetch 유틸리티
@@ -24,12 +24,12 @@ import { ENV } from './env';
 
 type BaseRequestOptions = Omit<FetchRequestOptions, 'body' | 'isFormData'>;
 
-type RequestConfig = {
-  endpoint: string;
-  method: RequestInit['method'];
-  body?: unknown;
-  query?: QueryParams;
-} & Omit<FetchRequestOptions, 'body'>;
+// type RequestConfig = {
+//   endpoint: string;
+//   method: RequestInit['method'];
+//   body?: unknown;
+//   query?: QueryParams;
+// } & Omit<FetchRequestOptions, 'body'>;
 
 const request = <T>({ endpoint, method, body, query, ...options }: RequestConfig) =>
   coreFetch<T>(ENV.API_BASE_URL, endpoint, { ...options, method }, query, body);

--- a/src/shared/apis/serverFetch.ts
+++ b/src/shared/apis/serverFetch.ts
@@ -1,6 +1,11 @@
 import { cookies } from 'next/headers';
+import {
+  coreFetch,
+  FetchRequestOptions,
+  QueryParams,
+  RequestConfig,
+} from '@/shared/apis/coreFetch';
 import { ENV } from '@/shared/apis/env';
-import { coreFetch, FetchRequestOptions, QueryParams, RequestConfig } from './coreFetch';
 
 /**
  * 서버 사이드 전용 Fetch 함수 (Server Components, Route Handlers, Server Actions 전용)

--- a/src/shared/apis/serverFetch.ts
+++ b/src/shared/apis/serverFetch.ts
@@ -41,7 +41,7 @@ const request = async <T>({
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  return coreFetch<T>(ENV.API_BASE_URL, endpoint, { ...options, method, headers }, query, body);
+  return coreFetch<T>(ENV.SERVER_API_URL, endpoint, { ...options, method, headers }, query, body);
 };
 
 /** HTTP 메서드 유틸리티 */

--- a/src/shared/apis/serverFetch.ts
+++ b/src/shared/apis/serverFetch.ts
@@ -31,9 +31,9 @@ const request = async <T>({
   const cookieStore = await cookies();
   const token = cookieStore.get('accessToken')?.value;
 
-  const headers = new Headers(options.headers);
+  const headers = Object.fromEntries(new Headers(options.headers).entries());
   if (token) {
-    headers.set('Authorization', `Bearer ${token}`);
+    headers['Authorization'] = `Bearer ${token}`;
   }
 
   return coreFetch<T>(ENV.API_BASE_URL, endpoint, { ...options, method, headers }, query, body);

--- a/src/shared/apis/serverFetch.ts
+++ b/src/shared/apis/serverFetch.ts
@@ -1,0 +1,67 @@
+import { cookies } from 'next/headers';
+import { ENV } from '@/shared/apis/env';
+import { coreFetch, FetchRequestOptions, QueryParams, RequestConfig } from './coreFetch';
+
+/**
+ * 서버 사이드 전용 Fetch 함수 (Server Components, Route Handlers, Server Actions 전용)
+ *
+ * - Base URL: process.env.API_URL
+ * - 인증: 서버 쿠키에서 읽은 Bearer 토큰을 Authorization 헤더에 주입
+ *
+ * @example
+ * ```ts
+ * // GET 요청
+ * const user = await serverFetch.get<User>('/users/me');
+ *
+ * // POST 요청
+ * const data = await serverFetch.post<{ accessToken: string }>(
+ *  '/auth/tokens', { email, password }
+ * );
+ * ```
+ */
+
+/** serverFetch 내부 공통 요청 함수 */
+const request = async <T>({
+  endpoint,
+  method,
+  body,
+  query,
+  ...options
+}: RequestConfig): Promise<T | null> => {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('accessToken')?.value;
+
+  const headers = new Headers(options.headers);
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  return coreFetch<T>(ENV.API_BASE_URL, endpoint, { ...options, method, headers }, query, body);
+};
+
+/** HTTP 메서드 유틸리티 */
+export const serverFetch = {
+  get: <T>(endpoint: string, query?: QueryParams, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'GET', query, ...options }),
+
+  post: <T>(endpoint: string, body?: unknown, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'POST', body, ...options }),
+
+  put: <T>(endpoint: string, body?: unknown, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'PUT', body, ...options }),
+
+  patch: <T>(endpoint: string, body?: unknown, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'PATCH', body, ...options }),
+
+  delete: <T>(endpoint: string, options?: FetchRequestOptions) =>
+    request<T>({ endpoint, method: 'DELETE', ...options }),
+
+  postFormData: <T>(endpoint: string, formData: FormData, options?: FetchRequestOptions) =>
+    request<T>({
+      endpoint,
+      method: 'POST',
+      body: formData,
+      isFormData: true,
+      ...options,
+    }),
+};

--- a/src/shared/apis/serverFetch.ts
+++ b/src/shared/apis/serverFetch.ts
@@ -10,7 +10,7 @@ import { ENV } from '@/shared/apis/env';
 /**
  * 서버 사이드 전용 Fetch 함수 (Server Components, Route Handlers, Server Actions 전용)
  *
- * - Base URL: process.env.API_URL
+ * - Base URL: process.env.NEXT_PUBLIC_BASE_URL
  * - 인증: 서버 쿠키에서 읽은 Bearer 토큰을 Authorization 헤더에 주입
  *
  * @example


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #97

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

혜원님이 작성해주신 publicFetch 함수 참고해서 http 메소드 유틸리티도 작성해봤습니당

`serverFetch`
- 서버 사이드 전용 fetch 함수
- `process.env.API_URL`을 base URL로 사용
- 서버 쿠키에서 `accessToken`을 읽어 `Authorization` 헤더에 자동으로 주입

`bffFetch`
- Next.js API Route(/api)를 통한 요청 전용 fetch 함수
- 상대 경로를 base URL로 사용
- 인증 정보(쿠키)는 브라우저가 자동으로 포함
- 클라이언트에서 인증이 필요한 요청 처리 시 사용

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

🙋🏻‍♀️ publicFetch에 정의된 `RequestConfig`가 serverFetch랑 bffFetch에도 공통으로 사용돼서 coreFetch 함수에 정의했습니다!
혹시나해서 publicFetch에 주석 처리 해놓고 푸시했는데 문제없으면 지우고 다시 푸시하겠습니다ㅎㅎ

> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
