### PR TITLE
[✨ Feat/#123] SelectDropdown&FormLabel 접근성 개선

### DIFF
--- a/src/shared/ui/dropdown/select/SelectDropdown.stories.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdown.stories.tsx
@@ -8,6 +8,7 @@ import {
   SelectDropdownTrigger,
   SelectDropdownValue,
 } from '@/shared/ui/dropdown/select';
+import FormLabel from '@/shared/ui/form/FormLabel';
 
 type ActivityCategory = '' | '문화 · 예술' | '식음료' | '투어' | '관광' | '웰빙';
 
@@ -183,16 +184,13 @@ Label과 함께 사용하는 SelectDropdown 예시입니다.
   render: (args) => {
     const [{ value }, updateArgs] = useArgs<{ value: ActivityCategory | '' }>();
     const triggerRef = useRef<HTMLButtonElement>(null);
+    const labelId = 'category-label';
 
     return (
       <div className="flex h-90 w-90 flex-col gap-2">
-        <button
-          type="button"
-          className="w-fit text-left font-medium"
-          onClick={() => triggerRef.current?.focus()}
-        >
+        <FormLabel id={labelId} weight="medium" onClick={() => triggerRef.current?.focus()}>
           카테고리
-        </button>
+        </FormLabel>
 
         <SelectDropdown
           {...args}
@@ -201,7 +199,7 @@ Label과 함께 사용하는 SelectDropdown 예시입니다.
             updateArgs({ value: nextValue as ActivityCategory | '' });
           }}
         >
-          <SelectDropdownTrigger ref={triggerRef}>
+          <SelectDropdownTrigger ref={triggerRef} ariaLabelledBy={labelId}>
             <SelectDropdownValue
               placeholder="카테고리 선택"
               render={(value: string) => CATEGORY_OPTIONS.find((opt) => opt.value === value)?.label}

--- a/src/shared/ui/form/FormLabel.tsx
+++ b/src/shared/ui/form/FormLabel.tsx
@@ -1,19 +1,46 @@
-import type { ComponentProps } from 'react';
+import type { ButtonHTMLAttributes, ComponentProps } from 'react';
 import { cn } from '@/shared/utils/cn';
 
-type FormLabelProps = ComponentProps<'label'> & {
+type BaseProps = {
   weight?: 'medium' | 'bold';
 };
 
 /**
+ * `htmlFor`를 받지 않는 Label props 타입입니다.
+ *
+ * @remarks
+ * `htmlFor`가 없을 때 `FormLabel`은 `<button>`으로 렌더링됩니다.
+ */
+type ClickableFormLabelProps = BaseProps &
+  ButtonHTMLAttributes<HTMLButtonElement> & {
+    htmlFor?: undefined;
+  };
+
+type NativeFormLabelProps = BaseProps & ComponentProps<'label'> & { htmlFor: string };
+
+type FormLabelProps = ClickableFormLabelProps | NativeFormLabelProps;
+
+/**
+ * ### FormLabel
+ *
  * 제목을 나타내는 Label 컴포넌트입니다.
  * `weight` 속성을 통해 글꼴의 굵기를 조절할 수 있습니다.
+ *
  * @example
  * ```tsx
  * // 기본 굵기 (medium) 적용
  * <FormLabel htmlFor="email">이메일</FormLabel>
  * // 강조된 굵기 (bold) 적용
  * <FormLabel htmlFor="password" weight="bold">비밀번호</FormLabel>
+ * ```
+ *
+ * @example
+ * ```tsx
+ *
+ * // 드롭다운 컴포넌트(SelectDropdownTrigger 등)에 포커스 위임
+ * <FormLabel onClick={() => triggerRef.current?.focus()}>
+ *   카테고리
+ * </FormLabel>
  * ```
  */
 export default function FormLabel({
@@ -22,16 +49,29 @@ export default function FormLabel({
   className,
   ...props
 }: FormLabelProps) {
+  const baseClassName = cn(
+    'block text-gray-950',
+    weight === 'bold' ? 'typo-16-bold' : 'typo-16-medium',
+    className
+  );
+
+  if ('htmlFor' in props && props.htmlFor) {
+    return (
+      <label className={baseClassName} {...props}>
+        {children}
+      </label>
+    );
+  }
+
+  const { type, ...buttonProps } = props as ClickableFormLabelProps;
+
   return (
-    <label
-      className={cn(
-        'block text-gray-950',
-        weight === 'bold' ? 'typo-16-bold' : 'typo-16-medium',
-        className
-      )}
-      {...props}
+    <button
+      type={type ?? 'button'}
+      className={cn(baseClassName, 'w-fit text-left')}
+      {...buttonProps}
     >
       {children}
-    </label>
+    </button>
   );
 }

--- a/src/shared/ui/form/FormLabel.tsx
+++ b/src/shared/ui/form/FormLabel.tsx
@@ -68,7 +68,7 @@ export default function FormLabel({
   return (
     <button
       type={type ?? 'button'}
-      className={cn(baseClassName, 'w-fit text-left')}
+      className={cn(baseClassName, 'w-fit cursor-pointer border-none bg-transparent p-0 text-left')}
       {...buttonProps}
     >
       {children}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #123

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- FormLabel이 htmlFor 유무에 따라 <label> / <button type="button">으로 렌더링되도록 개선했습니다.
- 커스텀 드롭다운(SelectDropdownTrigger)에 대해 FormLabel 클릭 시 트리거로 포커스가 이동할 수 있도록 사용 패턴을 지원했습니다.
- SelectDropdownTrigger에 ariaLabelledBy를 추가해 Label(id)과 aria-labelledby로 접근성 연결이 가능하도록 했습니다.
- 스토리북 예시에 실제 FormLabel을 활용해 Label id + ariaLabelledBy 연결 패턴을 반영했습니다.

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
