### PR TITLE
[♻️ Refactor/#121] 공통 버튼 및 input 스타일 정리

### DIFF
--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -16,7 +16,7 @@ button:disabled {
 }
 
 button[data-disabled='true'] {
-  cursor: default;
+  cursor: not-allowed;
 }
 
 button[data-loading='true'] {

--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -6,3 +6,19 @@
 @import './input.css';
 @import './layout.css';
 @import './overlay.css';
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+button[data-disabled='true'] {
+  cursor: default;
+}
+
+button[data-loading='true'] {
+  cursor: wait;
+}

--- a/src/shared/styles/input.css
+++ b/src/shared/styles/input.css
@@ -1,25 +1,40 @@
-@utility input-base {
-  height: 3.375rem; /* h-13.5 */
-  width: 100%;
-  border-radius: 1rem; /* rounded-2xl */
-  padding: 0 1.25rem; /* px-5 */
+@utility field-surface {
+  border: 1px solid var(--color-gray-100);
+  background-color: white;
+  color: var(--color-gray-950);
   outline: none;
   transition:
     color 0.2s,
     background-color 0.2s,
     border-color 0.2s;
 
-  border: 1px solid var(--color-gray-100);
-  background-color: white;
-  color: var(--color-gray-950);
+  &:focus,
+  &:focus-within {
+    border-width: 1.5px;
+    border-color: var(--color-primary-500);
+  }
 
-  &::placeholder {
+  &:disabled,
+  &[aria-disabled='true'] {
+    cursor: not-allowed;
+    border-color: var(--color-gray-200);
+    background-color: var(--color-gray-25);
     color: var(--color-gray-400);
   }
 
-  &:focus {
-    border-width: 1.5px;
-    border-color: var(--color-primary-500);
+  &[aria-invalid='true'],
+  &[data-error='true'] {
+    border-color: var(--color-error);
+  }
+}
+
+@utility field-control {
+  background-color: transparent;
+  color: var(--color-gray-950);
+  outline: none;
+
+  &::placeholder {
+    color: var(--color-gray-400);
   }
 
   &:focus::placeholder {
@@ -28,12 +43,35 @@
 
   &:disabled {
     cursor: not-allowed;
-    border-color: var(--color-gray-200);
-    background-color: var(--color-gray-25);
     color: var(--color-gray-400);
   }
 
   &[aria-invalid='true'] {
     border-color: var(--color-error);
   }
+}
+
+@utility field-input {
+  color: var(--color-gray-950);
+  outline: none;
+
+  &::placeholder {
+    color: var(--color-gray-400);
+  }
+
+  &:focus::placeholder {
+    color: transparent;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    color: var(--color-gray-400);
+  }
+}
+
+@utility input-size-base {
+  height: 3.375rem; /* h-13.5 */
+  width: 100%;
+  border-radius: 1rem; /* rounded-2xl */
+  padding: 0 1.25rem; /* px-5 */
 }

--- a/src/shared/styles/input.css
+++ b/src/shared/styles/input.css
@@ -30,25 +30,6 @@
 
 @utility field-control {
   background-color: transparent;
-  color: var(--color-gray-950);
-  outline: none;
-
-  &::placeholder {
-    color: var(--color-gray-400);
-  }
-
-  &:focus::placeholder {
-    color: transparent;
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    color: var(--color-gray-400);
-  }
-
-  &[aria-invalid='true'] {
-    border-color: var(--color-error);
-  }
 }
 
 @utility field-input {

--- a/src/shared/ui/button/Button.tsx
+++ b/src/shared/ui/button/Button.tsx
@@ -7,7 +7,7 @@ import Loading from '@/shared/ui/loading/Loading';
 import { cn } from '@/shared/utils/cn';
 
 const buttonStyle = cva(
-  'relative inline-flex items-center justify-center whitespace-nowrap rounded-[14px] border transition-colors cursor-pointer aria-disabled:cursor-not-allowed',
+  'relative inline-flex items-center justify-center whitespace-nowrap rounded-[14px] border transition-colors',
   {
     variants: {
       theme: {
@@ -83,6 +83,8 @@ export default function Button<T extends ElementType = 'button'>({
     <Component
       aria-disabled={isDisabled}
       aria-busy={isLoading || undefined}
+      data-disabled={isDisabled || undefined}
+      data-loading={isLoading || undefined}
       className={cn(buttonStyle({ theme, size }), className)}
       onClick={handleClick}
       {...(isButtonElement

--- a/src/shared/ui/dropdown/select/SelectDropdownTrigger.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdownTrigger.tsx
@@ -11,10 +11,8 @@ import { cn } from '@/shared/utils/cn';
 const selectDropdownTriggerVariants = cva('flex items-center', {
   variants: {
     variants: {
-      basic:
-        'w-full justify-between rounded-2xl border border-gray-100 bg-white px-4 h-13.5 outline-none focus-within:border-[1.5px] focus-within:border-primary-500',
-      shadow:
-        'gap-4 border border-gray-100 shadow rounded-lg px-4 py-2 typo-16-medium focus-within:border-[1.5px]',
+      basic: 'field-surface w-full justify-between rounded-2xl px-4 h-13.5',
+      shadow: 'field-surface gap-4 shadow rounded-lg px-4 py-2 typo-16-medium',
     },
   },
   defaultVariants: {

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -75,21 +75,14 @@ export default function UserNav({ theme, user, className, onLogout }: UserNavPro
   return (
     <div className={cn('flex items-center gap-5', className)}>
       {/* TODO: 알림 구현 */}
-      <button
-        type="button"
-        aria-label="알림"
-        className="flex h-6 w-6 cursor-pointer items-center justify-center"
-      >
+      <button type="button" aria-label="알림" className="flex h-6 w-6 items-center justify-center">
         <NotificationIcon aria-hidden="true" className={notificationIconVariants({ theme })} />
       </button>
 
       <span aria-hidden="true" className={dividerVariants()} />
 
       <ActionDropdown>
-        <ActionDropdownTrigger
-          className="flex cursor-pointer items-center"
-          ariaLabel="유저 메뉴 열기"
-        >
+        <ActionDropdownTrigger className="flex items-center" ariaLabel="유저 메뉴 열기">
           <Profile user={user} size="sm" nicknameClassName={profileNicknameVariants({ theme })} />
         </ActionDropdownTrigger>
 

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -37,7 +37,11 @@ export default function Input({
         {...props}
         disabled={disabled}
         aria-invalid={isError || undefined}
-        className={cn('input-base typo-16-medium', rightElement && 'pr-12', className)}
+        className={cn(
+          'input-size-base field-surface field-input typo-16-medium',
+          rightElement && 'pr-12',
+          className
+        )}
       />
       {rightElement && (
         <div className="absolute top-1/2 right-5 flex -translate-y-1/2 items-center justify-center text-gray-400">

--- a/src/shared/ui/page-header/PageHeader.tsx
+++ b/src/shared/ui/page-header/PageHeader.tsx
@@ -39,12 +39,7 @@ export default function PageHeader({ title, description, onBack }: PageHeaderPro
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center gap-1">
-        <button
-          type="button"
-          onClick={onBack}
-          aria-label="이전 페이지로 이동"
-          className="cursor-pointer"
-        >
+        <button type="button" onClick={onBack} aria-label="이전 페이지로 이동">
           <BackIcon />
         </button>
         <Title as="h1" size="18" weight="bold">

--- a/src/shared/ui/pagination/Pagination.tsx
+++ b/src/shared/ui/pagination/Pagination.tsx
@@ -24,10 +24,10 @@ const pageButtonVariants = cva(
   {
     variants: {
       state: {
-        page: 'typo-14-medium text-gray-300 cursor-pointer hover:text-gray-600', // 일반 숫자 버튼
+        page: 'typo-14-medium text-gray-300 hover:text-gray-600', // 일반 숫자 버튼
         pageActive: 'typo-14-bold text-gray-950 border-b-2 border-primary-500', // 현재 페이지 숫자 버튼
-        arrow: 'text-gray-950 cursor-pointer hover:text-primary-700', // 활성 화살표 버튼
-        arrowDisabled: 'text-gray-300 cursor-not-allowed', // 비활성 화살표 버튼
+        arrow: 'text-gray-950 hover:text-primary-700', // 활성 화살표 버튼
+        arrowDisabled: 'text-gray-300', // 비활성 화살표 버튼
       },
     },
     defaultVariants: {

--- a/src/shared/ui/search-input/SearchInputField.tsx
+++ b/src/shared/ui/search-input/SearchInputField.tsx
@@ -34,7 +34,7 @@ const SearchInputUi = forwardRef<HTMLInputElement, SearchInputUiProps>(
         />
         <button
           type="submit"
-          className="absolute top-1/2 right-5 -translate-y-1/2 cursor-pointer"
+          className="absolute top-1/2 right-5 -translate-y-1/2"
           aria-label="검색"
         >
           <SearchIcon />

--- a/src/shared/ui/search-input/SearchInputField.tsx
+++ b/src/shared/ui/search-input/SearchInputField.tsx
@@ -28,7 +28,7 @@ const SearchInputUi = forwardRef<HTMLInputElement, SearchInputUiProps>(
           placeholder={placeholder}
           aria-label="검색어 입력"
           className={cn(
-            'input-base',
+            'field-surface field-input',
             'h-15.5 rounded-[20px] px-5 py-5.5 pr-14 typo-14-medium shadow-drop md:h-17.5 md:rounded-3xl md:px-8 md:py-6 md:pr-22 md:typo-18-medium'
           )}
         />

--- a/src/shared/ui/tab-bar/styles/tabVariants.ts
+++ b/src/shared/ui/tab-bar/styles/tabVariants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const tabVariants = cva(
-  'h-10 cursor-pointer flex items-center justify-center -mb-px', // 모든 탭에 공통으로 적용될 스타일
+  'h-10 flex items-center justify-center -mb-px', // 모든 탭에 공통으로 적용될 스타일
   {
     variants: {
       state: {

--- a/src/shared/ui/textarea/Textarea.tsx
+++ b/src/shared/ui/textarea/Textarea.tsx
@@ -5,20 +5,17 @@ import { useState, type ChangeEvent, type ComponentProps, type Ref } from 'react
 import { cn } from '@/shared/utils/cn';
 
 // NOTE: 스크롤바를 패딩 안쪽에 위치시키기 위해 textarea가 아닌 wrapper에 border와 padding을 적용
-const containerVariants = cva(
-  'flex w-full flex-col bg-white border border-gray-100 transition-colors focus-within:border-[1.5px] focus-within:border-primary-500',
-  {
-    variants: {
-      variant: {
-        review: 'h-44.75 rounded-xl px-5 py-5',
-        activity: 'h-35 rounded-2xl px-5 py-4 md:h-50',
-      },
+const containerVariants = cva('field-surface flex w-full flex-col', {
+  variants: {
+    variant: {
+      review: 'h-44.75 rounded-xl px-5 py-5',
+      activity: 'h-35 rounded-2xl px-5 py-4 md:h-50',
     },
-    defaultVariants: {
-      variant: 'activity',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    variant: 'activity',
+  },
+});
 
 type TextareaProps = ComponentProps<'textarea'> &
   VariantProps<typeof containerVariants> & {
@@ -90,7 +87,7 @@ export default function Textarea({
           onChange={handleChange}
           aria-invalid={isError}
           className={cn(
-            'h-full w-full resize-none bg-transparent text-gray-950 outline-none placeholder:text-gray-400',
+            'h-full w-full field-control resize-none',
             'typo-14-medium md:typo-16-medium',
             'scrollbar-mini',
             className

--- a/src/shared/ui/textarea/Textarea.tsx
+++ b/src/shared/ui/textarea/Textarea.tsx
@@ -87,7 +87,7 @@ export default function Textarea({
           onChange={handleChange}
           aria-invalid={isError}
           className={cn(
-            'h-full w-full field-control resize-none',
+            'h-full w-full field-input resize-none field-control',
             'typo-14-medium md:typo-16-medium',
             'scrollbar-mini',
             className

--- a/src/shared/ui/textarea/Textarea.tsx
+++ b/src/shared/ui/textarea/Textarea.tsx
@@ -73,11 +73,8 @@ export default function Textarea({
   return (
     <div className={cn('w-full', wrapperClassName)}>
       <div
-        className={cn(
-          'relative',
-          containerVariants({ variant }),
-          isError && 'border-error focus-within:border-error'
-        )}
+        data-error={isError || undefined}
+        className={cn('relative', containerVariants({ variant }))}
       >
         <textarea
           ref={ref}

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -59,7 +59,7 @@ export default function Toast({ type, message, onClose }: ToastProps) {
         type="button"
         onClick={handleClose}
         aria-label="토스트 닫기"
-        className="ml-3 shrink-0 cursor-pointer md:ml-5"
+        className="ml-3 shrink-0 md:ml-5"
       >
         <DeleteIcon className="h-6 w-6 text-gray-100 md:h-8 md:w-8" />
       </button>


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #121 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 버튼 공통 스타일
- src/shared/styles/globals.css에 버튼 커서 스타일을 전역 적용(button, :disabled, data-disabled, data-loading)
- 중복되는 cursor-* 클래스들을 컴포넌트/variants에서 제거하여 전역 스타일로 통일화(추후에 button 태그에는 cursor-pointer 관련으로 신경쓰지 않아도 됨!)
- Button에서 전역 커서 제어가 가능하도록 data-disabled, data-loading 속성 추가

### input 공통 스타일
- src/shared/styles/input.css에 필드 공통 유틸 추가: field-surface, field-control, field-input, input-size-base
- Textarea, SelectDropdownTrigger, Input, SearchInput에 공통 유틸 적용하여 border/bg/focus/placeholder/disabled 스타일을 input.css로 통합
- Input, SearchInput을 input-base에서 field-* 유틸 기반으로 마이그레이션하고, 미사용 input-base 제거

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
