### PR TITLE
[✨ Feat/#130] 로그인 기능 구현

### DIFF
--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -2,7 +2,7 @@
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
-import { COMMON_MESSAGE } from '@/features/auth/constants/authMessage';
+import { AUTH_API_MESSAGE } from '@/features/auth/constants/authMessage';
 import { LoginRequest, UserData } from '@/features/auth/types/auth';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
@@ -13,6 +13,7 @@ import Button from '@/shared/ui/button/Button';
 import FormField from '@/shared/ui/form/FormField';
 import FormInput from '@/shared/ui/form/FormInput';
 import PasswordInput from '@/shared/ui/input/PasswordInput';
+import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 import { cn } from '@/shared/utils/cn';
 
 /**
@@ -23,6 +24,7 @@ import { cn } from '@/shared/utils/cn';
 export default function LoginPage() {
   const router = useRouter();
   const { setAuth } = useAuthStore();
+  const { showToast } = useToastStore();
   const {
     control,
     handleSubmit,
@@ -61,6 +63,9 @@ export default function LoginPage() {
             expiresAt
           );
 
+          // 로그인 성공 토스트
+          showToast('check', AUTH_API_MESSAGE.LOGIN.SUCCESS);
+
           // 쿠키 상태 동기화를 위해 refresh 후 이동
           router.refresh();
           router.push('/');
@@ -74,14 +79,11 @@ export default function LoginPage() {
           });
         } else {
           // 네트워크 에러 등
-          setError('root', {
-            type: 'server',
-            message: COMMON_MESSAGE.ERROR.NETWORK,
-          });
+          showToast('cancel', '로그인 중 오류가 발생했습니다.');
         }
       }
     },
-    [router, setAuth, setError]
+    [router, setAuth, setError, showToast]
   );
 
   return (

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
     control,
     handleSubmit,
     setError,
-    formState: { isSubmitting, isValid, errors },
+    formState: { isSubmitting, errors, isDirty },
   } = useForm({
     defaultValues: {
       email: '',
@@ -112,7 +112,7 @@ export default function LoginPage() {
             theme="primary"
             size="lg"
             isLoading={isSubmitting}
-            disabled={!isValid || isSubmitting}
+            disabled={!isDirty || isSubmitting}
             className={cn('mt-1 h-13.5 w-full rounded-2xl', !errors.root && 'md:mt-2')}
           >
             로그인 하기

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -1,11 +1,35 @@
 'use client';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
+import { useAuthStore } from '@/shared/stores/useAuthStore';
 import Button from '@/shared/ui/button/Button';
 import FormField from '@/shared/ui/form/FormField';
 import FormInput from '@/shared/ui/form/FormInput';
 import PasswordInput from '@/shared/ui/input/PasswordInput';
+import { cn } from '@/shared/utils/cn';
+
+// TODO : '라우트 구현' PR 머지 후 auth/type.ts에 재정의 필요
+// type User = {
+//   id: number;
+//   email: string;
+//   nickname: string;
+//   profileImageUrl: string | null;
+//   createdAt: string;
+//   updatedAt: string;
+// };
+
+// type LoginResponse = {
+//   accessToken: string;
+//   refreshToken: string;
+//   user: User;
+// };
+
+type LoginRequest = {
+  email: string;
+  password: string;
+};
 
 /**
  * 로그인 페이지 컴포넌트입니다.
@@ -13,10 +37,13 @@ import PasswordInput from '@/shared/ui/input/PasswordInput';
  * 하단에 카카오 로그인 및 회원가입 페이지 이동 링크가 포함됩니다.
  */
 export default function LoginPage() {
+  const router = useRouter();
+  const { setAuth } = useAuthStore();
   const {
     control,
     handleSubmit,
-    formState: { isSubmitting, isValid },
+    setError,
+    formState: { isSubmitting, isValid, errors },
   } = useForm({
     defaultValues: {
       email: '',
@@ -25,7 +52,35 @@ export default function LoginPage() {
     mode: 'onChange',
   });
 
-  const handleLogin = () => {};
+  const handleLogin = async (formData: LoginRequest) => {
+    try {
+      // const result = await bffFetch.post<LoginResponse>('/auth/login', formData);
+
+      const response = await fetch('https://sp-globalnomad-api.vercel.app/22-1/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+      });
+      const result = await response.json();
+
+      if (result?.user) {
+        // TODO : login/route.ts에 expiresAt 추가 필요
+        // 전역 상태(Zustand) 업데이트
+        setAuth(result.user, result.expiresAt);
+
+        // 메인 페이지로 이동
+        router.push('/');
+      }
+    } catch (error) {
+      console.log(error);
+      setError('root', {
+        type: 'server',
+        message: '이메일 또는 비밀번호가 일치하지 않습니다.',
+      });
+    }
+  };
 
   return (
     <>
@@ -42,13 +97,19 @@ export default function LoginPage() {
         <FormField label="비밀번호">
           <PasswordInput name="password" control={control} placeholder="비밀번호를 입력해 주세요" />
         </FormField>
+
+        {/* API 에러 메시지 */}
+        {errors.root && (
+          <p className="translate-y-3 typo-13-medium text-red-500">{errors.root.message}</p>
+        )}
+
         <Button
           type="submit"
           theme="primary"
           size="lg"
           isLoading={isSubmitting}
           disabled={!isValid || isSubmitting}
-          className="mt-2 h-13.5 w-full rounded-2xl md:mt-2.5"
+          className={cn('h-13.5 w-full rounded-2xl md:mt-2.5', errors.root ? 'mt-0' : 'mt-2')}
         >
           로그인 하기
         </Button>

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -2,13 +2,12 @@
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
+import { loginUser } from '@/features/auth/apis';
 import { AUTH_API_MESSAGE } from '@/features/auth/constants/authMessage';
-import { LoginRequest } from '@/features/auth/types/auth';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
-import { UserResponse } from '@/features/user/types';
+import { LoginFormValues } from '@/features/auth/utils/schema';
 import { ApiError } from '@/shared/apis/apiError';
-import { bffFetch } from '@/shared/apis/base/bffFetch';
 import { useAuthStore } from '@/shared/stores/useAuthStore';
 import Button from '@/shared/ui/button/Button';
 import FormField from '@/shared/ui/form/FormField';
@@ -41,12 +40,10 @@ export default function LoginPage() {
 
   /** 로그인 요청 핸들러 */
   const handleLogin = useCallback(
-    async (formData: LoginRequest) => {
+    async (formData: LoginFormValues) => {
       try {
-        const response = await bffFetch.post<{ success: boolean; user: UserResponse }>(
-          '/auth/login',
-          formData
-        );
+        const response = await loginUser(formData);
+
         if (response) {
           const { user } = response;
 

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -2,7 +2,7 @@
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
-import { LoginRequest, LoginResponse } from '@/features/auth/types';
+import { LoginRequest, LoginResponse } from '@/features/auth/types/auth';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
 import { bffFetch } from '@/shared/apis/base/bffFetch';

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -47,7 +47,7 @@ export default function LoginPage() {
 
           // 토큰 만료 시간 계산 (현재 시간 기준 30분)
           const EXPIRE_TIME = 1000 * 60 * 30;
-          const expiresIn = Date.now() + EXPIRE_TIME;
+          const expiresAt = Date.now() + EXPIRE_TIME;
 
           // 전역 상태(Zustand) 업데이트
           setAuth(
@@ -56,7 +56,7 @@ export default function LoginPage() {
               email: user.email,
               nickname: user.nickname,
             },
-            expiresIn
+            expiresAt
           );
 
           // 쿠키 상태 동기화를 위해 refresh 후 이동

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
+import { LoginRequest, LoginResponse } from '@/features/auth/types';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
+import { bffFetch } from '@/shared/apis/base/bffFetch';
 import { useAuthStore } from '@/shared/stores/useAuthStore';
 import Button from '@/shared/ui/button/Button';
 import FormField from '@/shared/ui/form/FormField';
@@ -10,31 +13,10 @@ import FormInput from '@/shared/ui/form/FormInput';
 import PasswordInput from '@/shared/ui/input/PasswordInput';
 import { cn } from '@/shared/utils/cn';
 
-// TODO : '라우트 구현' PR 머지 후 auth/type.ts에 재정의 필요
-// type User = {
-//   id: number;
-//   email: string;
-//   nickname: string;
-//   profileImageUrl: string | null;
-//   createdAt: string;
-//   updatedAt: string;
-// };
-
-// type LoginResponse = {
-//   accessToken: string;
-//   refreshToken: string;
-//   user: User;
-// };
-
-type LoginRequest = {
-  email: string;
-  password: string;
-};
-
 /**
  * 로그인 페이지 컴포넌트입니다.
- * 이메일과 비밀번호 입력 폼을 제공하며, react-hook-form으로 폼 상태를 관리합니다.
- * 하단에 카카오 로그인 및 회원가입 페이지 이동 링크가 포함됩니다.
+ * 이메일과 비밀번호를 통한 인증을 처리합니다.
+ * 성공 시 유저 정보를 Zustand 스토어에 저장하고 메인 페이지로 이동합니다.
  */
 export default function LoginPage() {
   const router = useRouter();
@@ -52,35 +34,43 @@ export default function LoginPage() {
     mode: 'onChange',
   });
 
-  const handleLogin = async (formData: LoginRequest) => {
-    try {
-      // const result = await bffFetch.post<LoginResponse>('/auth/login', formData);
+  /** 로그인 요청 핸들러 */
+  const handleLogin = useCallback(
+    async (formData: LoginRequest) => {
+      try {
+        const response = await bffFetch.post<LoginResponse>('/auth/login', formData);
 
-      const response = await fetch('https://sp-globalnomad-api.vercel.app/22-1/auth/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      });
-      const result = await response.json();
+        if (response) {
+          const { user } = response;
 
-      if (result?.user) {
-        // TODO : login/route.ts에 expiresAt 추가 필요
-        // 전역 상태(Zustand) 업데이트
-        setAuth(result.user, result.expiresAt);
+          // 토큰 만료 시간 계산 (현재 시간 기준 30분)
+          const EXPIRE_TIME = 1000 * 60 * 30;
+          const expiresIn = Date.now() + EXPIRE_TIME;
 
-        // 메인 페이지로 이동
-        router.push('/');
+          // 전역 상태(Zustand) 업데이트
+          setAuth(
+            {
+              id: user.id,
+              email: user.email,
+              nickname: user.nickname,
+            },
+            expiresIn
+          );
+
+          // 쿠키 상태 동기화를 위해 refresh 후 이동
+          router.push('/');
+          router.refresh();
+        }
+      } catch {
+        // react-hook-form의 root 에러 설정
+        setError('root', {
+          type: 'server',
+          message: '이메일 또는 비밀번호가 일치하지 않습니다.',
+        });
       }
-    } catch (error) {
-      console.log(error);
-      setError('root', {
-        type: 'server',
-        message: '이메일 또는 비밀번호가 일치하지 않습니다.',
-      });
-    }
-  };
+    },
+    [router, setAuth, setError]
+  );
 
   return (
     <>
@@ -100,7 +90,9 @@ export default function LoginPage() {
 
         {/* API 에러 메시지 */}
         {errors.root && (
-          <p className="translate-y-3 typo-13-medium text-red-500">{errors.root.message}</p>
+          <p className="translate-y-3 typo-13-medium text-red-500" role="alert">
+            {errors.root.message}
+          </p>
         )}
 
         <Button

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -101,7 +101,7 @@ export default function LoginPage() {
             size="lg"
             isLoading={isSubmitting}
             disabled={!isValid || isSubmitting}
-            className={cn('mt-1 h-13.5 w-full rounded-2xl', errors.root ? '' : 'md:mt-2')}
+            className={cn('mt-1 h-13.5 w-full rounded-2xl', !errors.root && 'md:mt-2')}
           >
             로그인 하기
           </Button>

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -87,24 +87,25 @@ export default function LoginPage() {
         <FormField label="비밀번호">
           <PasswordInput name="password" control={control} placeholder="비밀번호를 입력해 주세요" />
         </FormField>
+        <div className="mt-1 md:mt-2">
+          {/* API 에러 메시지 */}
+          {errors.root && (
+            <p className="typo-13-medium text-red-500" role="alert">
+              {errors.root.message}
+            </p>
+          )}
 
-        {/* API 에러 메시지 */}
-        {errors.root && (
-          <p className="translate-y-3 typo-13-medium text-red-500" role="alert">
-            {errors.root.message}
-          </p>
-        )}
-
-        <Button
-          type="submit"
-          theme="primary"
-          size="lg"
-          isLoading={isSubmitting}
-          disabled={!isValid || isSubmitting}
-          className={cn('h-13.5 w-full rounded-2xl md:mt-2.5', errors.root ? 'mt-0' : 'mt-2')}
-        >
-          로그인 하기
-        </Button>
+          <Button
+            type="submit"
+            theme="primary"
+            size="lg"
+            isLoading={isSubmitting}
+            disabled={!isValid || isSubmitting}
+            className={cn('mt-1 h-13.5 w-full rounded-2xl', errors.root ? '' : 'md:mt-2')}
+          >
+            로그인 하기
+          </Button>
+        </div>
       </AuthForm>
       <AuthFooter />
     </>

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -3,9 +3,10 @@ import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { AUTH_API_MESSAGE } from '@/features/auth/constants/authMessage';
-import { LoginRequest, UserData } from '@/features/auth/types/auth';
+import { LoginRequest } from '@/features/auth/types/auth';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
+import { UserResponse } from '@/features/user/types';
 import { ApiError } from '@/shared/apis/apiError';
 import { bffFetch } from '@/shared/apis/base/bffFetch';
 import { useAuthStore } from '@/shared/stores/useAuthStore';
@@ -42,7 +43,7 @@ export default function LoginPage() {
   const handleLogin = useCallback(
     async (formData: LoginRequest) => {
       try {
-        const response = await bffFetch.post<{ success: boolean; user: UserData }>(
+        const response = await bffFetch.post<{ success: boolean; user: UserResponse }>(
           '/auth/login',
           formData
         );

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -45,11 +45,7 @@ export default function LoginPage() {
         const response = await loginUser(formData);
 
         if (response) {
-          const { user } = response;
-
-          // 토큰 만료 시간 계산 (현재 시간 기준 30분)
-          const EXPIRE_TIME = 1000 * 60 * 30;
-          const expiresAt = Date.now() + EXPIRE_TIME;
+          const { user, expiresAt } = response;
 
           // 전역 상태(Zustand) 업데이트
           setAuth(

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -2,7 +2,7 @@
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
-import { LoginRequest, LoginResponse } from '@/features/auth/types/auth';
+import { LoginRequest, UserData } from '@/features/auth/types/auth';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
 import { bffFetch } from '@/shared/apis/base/bffFetch';
@@ -38,8 +38,10 @@ export default function LoginPage() {
   const handleLogin = useCallback(
     async (formData: LoginRequest) => {
       try {
-        const response = await bffFetch.post<LoginResponse>('/auth/login', formData);
-
+        const response = await bffFetch.post<{ success: boolean; user: UserData }>(
+          '/auth/login',
+          formData
+        );
         if (response) {
           const { user } = response;
 

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -5,7 +5,9 @@ import { useForm } from 'react-hook-form';
 import { LoginRequest, UserData } from '@/features/auth/types/auth';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
+import { ApiError } from '@/shared/apis/apiError';
 import { bffFetch } from '@/shared/apis/base/bffFetch';
+import { COMMON_MESSAGE } from '@/shared/constants/message';
 import { useAuthStore } from '@/shared/stores/useAuthStore';
 import Button from '@/shared/ui/button/Button';
 import FormField from '@/shared/ui/form/FormField';
@@ -63,12 +65,20 @@ export default function LoginPage() {
           router.push('/');
           router.refresh();
         }
-      } catch {
-        // react-hook-form의 root 에러 설정
-        setError('root', {
-          type: 'server',
-          message: '이메일 또는 비밀번호가 일치하지 않습니다.',
-        });
+      } catch (error) {
+        if (error instanceof ApiError) {
+          // 서버에서 내려온 에러 (401, 400 등)
+          setError('root', {
+            type: 'server',
+            message: error.message,
+          });
+        } else {
+          // 네트워크 에러 등
+          setError('root', {
+            type: 'server',
+            message: COMMON_MESSAGE.ERROR.NETWORK,
+          });
+        }
       }
     },
     [router, setAuth, setError]

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -2,12 +2,12 @@
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
+import { COMMON_MESSAGE } from '@/features/auth/constants/authMessage';
 import { LoginRequest, UserData } from '@/features/auth/types/auth';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
 import { ApiError } from '@/shared/apis/apiError';
 import { bffFetch } from '@/shared/apis/base/bffFetch';
-import { COMMON_MESSAGE } from '@/shared/constants/message';
 import { useAuthStore } from '@/shared/stores/useAuthStore';
 import Button from '@/shared/ui/button/Button';
 import FormField from '@/shared/ui/form/FormField';
@@ -62,8 +62,8 @@ export default function LoginPage() {
           );
 
           // 쿠키 상태 동기화를 위해 refresh 후 이동
-          router.push('/');
           router.refresh();
+          router.push('/');
         }
       } catch (error) {
         if (error instanceof ApiError) {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { AUTH_API_MESSAGE } from '@/features/auth/constants/authMessage';
 import { COOKIE_OPTIONS } from '@/features/auth/constants/cookies';
-import { LoginRequest, LoginResponse } from '@/features/auth/types/auth';
+import { LoginResponse } from '@/features/auth/types/auth';
+import { LoginFormValues } from '@/features/auth/utils/schema';
 import { ApiError } from '@/shared/apis/apiError';
 import { serverFetch } from '@/shared/apis/base/serverFetch';
 
@@ -19,7 +20,7 @@ import { serverFetch } from '@/shared/apis/base/serverFetch';
 export async function POST(request: Request) {
   try {
     // 1. 클라이언트에서 전달한 로그인 정보 파싱
-    const body: LoginRequest = await request.json();
+    const body: LoginFormValues = await request.json();
     const { email, password } = body;
 
     // 2. 로그인 API 호출
@@ -33,8 +34,12 @@ export async function POST(request: Request) {
       return NextResponse.json({ message: AUTH_API_MESSAGE.LOGIN.ERROR }, { status: 500 });
     }
 
+    // 토큰 만료 시간 계산 (현재 시간 기준 30분)
+    const EXPIRE_TIME = 1000 * 60 * 30;
+    const expiresAt = Date.now() + EXPIRE_TIME;
+
     // 응답 객체 생성 및 공통 쿠키 설정
-    const response = NextResponse.json({ success: true, user: data.user });
+    const response = NextResponse.json({ success: true, user: data.user, expiresAt: expiresAt });
 
     // 3. accessToken 쿠키 저장
     response.cookies.set('accessToken', data.accessToken, {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -10,6 +10,7 @@ import { serverFetch } from '@/shared/apis/base/serverFetch';
  * POST /api/auth/login
  * 로그인 라우트 핸들러입니다.
  *
+ *
  * [동작 흐름]
  * 1. 클라이언트로부터 이메일/비밀번호를 전달받는다.
  * 2. serverFetch를 통해 백엔드 /auth/login 호출

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     }
 
     // 응답 객체 생성 및 공통 쿠키 설정
-    const response = NextResponse.json({ success: true });
+    const response = NextResponse.json({ success: true, user: data.user });
 
     // 3. accessToken 쿠키 저장
     response.cookies.set('accessToken', data.accessToken, {

--- a/src/features/auth/apis.ts
+++ b/src/features/auth/apis.ts
@@ -1,0 +1,7 @@
+import { LoginFormValues } from '@/features/auth/utils/schema';
+import { UserResponse } from '@/features/user/types';
+import { bffFetch } from '@/shared/apis/base/bffFetch';
+
+export const loginUser = async (formData: LoginFormValues) => {
+  return await bffFetch.post<{ success: boolean; user: UserResponse }>('/auth/login', formData);
+};

--- a/src/features/auth/apis.ts
+++ b/src/features/auth/apis.ts
@@ -3,5 +3,8 @@ import { UserResponse } from '@/features/user/types';
 import { bffFetch } from '@/shared/apis/base/bffFetch';
 
 export const loginUser = async (formData: LoginFormValues) => {
-  return await bffFetch.post<{ success: boolean; user: UserResponse }>('/auth/login', formData);
+  return await bffFetch.post<{ success: boolean; user: UserResponse; expiresAt: number }>(
+    '/auth/login',
+    formData
+  );
 };

--- a/src/features/auth/constants/authMessage.ts
+++ b/src/features/auth/constants/authMessage.ts
@@ -1,9 +1,11 @@
 // API 응답 메시지 (서버 → 클라이언트)
 export const AUTH_API_MESSAGE = {
   LOGIN: {
+    SUCCESS: '로그인에 성공했습니다.',
     ERROR: '로그인에 실패했습니다.',
   },
   SIGNUP: {
+    SUCCESS: '회원가입에 성공했습니다.',
     ERROR: '회원가입에 실패했습니다.',
   },
   OAUTH: {

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -1,18 +1,10 @@
-/** 사용자 기본 정보 타입 */
-export type UserData = {
-  id: number;
-  email: string;
-  nickname: string;
-  profileImageUrl: string | null;
-  createdAt: string;
-  updatedAt: string;
-};
+import { UserResponse } from '@/features/user/types';
 
 /** POST /auth/login 응답  */
 export type LoginResponse = {
   accessToken: string;
   refreshToken: string;
-  user: UserData;
+  user: UserResponse;
 };
 
 /** POST /auth/login 리퀘스트 */

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -1,20 +1,27 @@
-import { UserResponse } from '@/features/user/types';
+import { z } from 'zod';
 
-/** POST /auth/login 응답  */
-export type LoginResponse = {
-  accessToken: string;
-  refreshToken: string;
-  user: UserResponse;
-};
+export const UserResponseSchema = z.object({
+  id: z.number(),
+  email: z.string().email(),
+  nickname: z.string(),
+  profileImageUrl: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
 
-/** POST /auth/login 리퀘스트 */
-export type LoginRequest = {
-  email: string;
-  password: string;
-};
+/** POST /auth/login 응답 */
+export const LoginResponseSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  user: UserResponseSchema,
+});
 
-/** POST /auth/tokens 응답  */
-export type RefreshResponse = {
-  accessToken: string;
-  refreshToken: string;
-};
+/** POST /auth/tokens 응답 */
+export const RefreshResponseSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+});
+
+export type LoginResponse = z.infer<typeof LoginResponseSchema>;
+export type UserResponse = z.infer<typeof UserResponseSchema>;
+export type RefreshResponse = z.infer<typeof RefreshResponseSchema>;

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -1,5 +1,5 @@
 /** 사용자 기본 정보 타입 */
-type User = {
+export type UserData = {
   id: number;
   email: string;
   nickname: string;
@@ -12,7 +12,7 @@ type User = {
 export type LoginResponse = {
   accessToken: string;
   refreshToken: string;
-  user: User;
+  user: UserData;
 };
 
 /** POST /auth/login 리퀘스트 */

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -1,12 +1,28 @@
+/** 사용자 기본 정보 타입 */
+type User = {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** POST /auth/login 응답  */
+export type LoginResponse = {
+  accessToken: string;
+  refreshToken: string;
+  user: User;
+};
+
+/** POST /auth/login 리퀘스트 */
 export type LoginRequest = {
   email: string;
   password: string;
 };
 
-type AuthResponse = {
+/** POST /auth/tokens 응답  */
+export type RefreshResponse = {
   accessToken: string;
   refreshToken: string;
 };
-
-export type LoginResponse = AuthResponse;
-export type RefreshResponse = AuthResponse;

--- a/src/shared/stores/useAuthStore.ts
+++ b/src/shared/stores/useAuthStore.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand';
+
+/**
+ * 사용자 기본 정보 타입
+ */
+type User = {
+  /** 사용자의 고유 식별자 (UUID) */
+  id: string;
+  /** 사용자 이메일 계정 */
+  email: string;
+  /** 사용자 닉네임 */
+  nickname: string;
+};
+
+/**
+ * 인증 관련 전역 상태 및 액션 객체 타입
+ */
+type AuthState = {
+  /** 현재 로그인한 사용자 정보 (비로그인 시 null) */
+  user: User | null;
+  /** 액세스 토큰의 만료 시각 */
+  expiresAt: number | null;
+  /**
+   * 사용자 정보와 만료 시각을 스토어에 저장합니다.
+   * @param user - 저장할 사용자 객체
+   * @param expiresAt - 토큰 만료 시각 (Timestamp)
+   */
+  setAuth: (user: User, expiresAt: number) => void;
+  /**
+   * 스토어에 저장된 인증 정보를 초기화(로그아웃 처리)합니다.
+   */
+  clearAuth: () => void;
+};
+
+/**
+ * 인증 상태를 전역으로 관리하는 Zustand store입니다.
+ *
+ * @example
+ * ```ts
+ * // 저장
+ * const { setAuth } = useAuthStore();
+ * setAuth(user, expiresAt);
+ *
+ * // 사용
+ * const { user } = useAuthStore();
+ * ```
+ */
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  expiresAt: null,
+
+  setAuth: (user, expiresAt) => set({ user, expiresAt }),
+  clearAuth: () => set({ user: null, expiresAt: null }),
+}));

--- a/src/shared/stores/useAuthStore.ts
+++ b/src/shared/stores/useAuthStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
-import { UserData } from '@/features/auth/types/auth';
+import { UserResponse } from '@/features/user/types';
 
-type UserInfoData = Pick<UserData, 'id' | 'email' | 'nickname'>;
+type UserInfoData = Pick<UserResponse, 'id' | 'email' | 'nickname'>;
 
 /**
  * 인증 관련 전역 상태 및 액션 객체 타입

--- a/src/shared/stores/useAuthStore.ts
+++ b/src/shared/stores/useAuthStore.ts
@@ -5,7 +5,7 @@ import { create } from 'zustand';
  */
 type User = {
   /** 사용자의 고유 식별자 (UUID) */
-  id: string;
+  id: number;
   /** 사용자 이메일 계정 */
   email: string;
   /** 사용자 닉네임 */
@@ -21,13 +21,13 @@ type AuthState = {
   /** 액세스 토큰의 만료 시각 */
   expiresAt: number | null;
   /**
-   * 사용자 정보와 만료 시각을 스토어에 저장합니다.
+   * 사용자 정보와 만료 시각을 스토어에 저장
    * @param user - 저장할 사용자 객체
    * @param expiresAt - 토큰 만료 시각 (Timestamp)
    */
   setAuth: (user: User, expiresAt: number) => void;
   /**
-   * 스토어에 저장된 인증 정보를 초기화(로그아웃 처리)합니다.
+   * 스토어에 저장된 인증 정보를 초기화(로그아웃 처리)
    */
   clearAuth: () => void;
 };

--- a/src/shared/stores/useAuthStore.ts
+++ b/src/shared/stores/useAuthStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
 import { UserData } from '@/features/auth/types/auth';
 
 type UserInfoData = Pick<UserData, 'id' | 'email' | 'nickname'>;
@@ -36,10 +37,14 @@ type AuthState = {
  * const { user } = useAuthStore();
  * ```
  */
-export const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  expiresAt: null,
-
-  setAuth: (user, expiresAt) => set({ user, expiresAt }),
-  clearAuth: () => set({ user: null, expiresAt: null }),
-}));
+export const useAuthStore = create<AuthState>()(
+  devtools(
+    (set) => ({
+      user: null,
+      expiresAt: null,
+      setAuth: (user, expiresAt) => set({ user, expiresAt }, false, 'setAuth'),
+      clearAuth: () => set({ user: null, expiresAt: null }, false, 'clearAuth'),
+    }),
+    { name: 'AuthStore' }
+  )
+);

--- a/src/shared/stores/useAuthStore.ts
+++ b/src/shared/stores/useAuthStore.ts
@@ -1,23 +1,14 @@
 import { create } from 'zustand';
+import { UserData } from '@/features/auth/types/auth';
 
-/**
- * 사용자 기본 정보 타입
- */
-type User = {
-  /** 사용자의 고유 식별자 (UUID) */
-  id: number;
-  /** 사용자 이메일 계정 */
-  email: string;
-  /** 사용자 닉네임 */
-  nickname: string;
-};
+type UserInfoData = Pick<UserData, 'id' | 'email' | 'nickname'>;
 
 /**
  * 인증 관련 전역 상태 및 액션 객체 타입
  */
 type AuthState = {
   /** 현재 로그인한 사용자 정보 (비로그인 시 null) */
-  user: User | null;
+  user: UserInfoData | null;
   /** 액세스 토큰의 만료 시각 */
   expiresAt: number | null;
   /**
@@ -25,7 +16,7 @@ type AuthState = {
    * @param user - 저장할 사용자 객체
    * @param expiresAt - 토큰 만료 시각 (Timestamp)
    */
-  setAuth: (user: User, expiresAt: number) => void;
+  setAuth: (user: UserInfoData, expiresAt: number) => void;
   /**
    * 스토어에 저장된 인증 정보를 초기화(로그아웃 처리)
    */


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #130

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

유저 정보 및 인증 상태 관리 전역 스토어 구현
- 토큰 만료 5분 전 토큰 재발급 처리를 위한 스토어
- 로그인 된 현재 시간부터 30분 계산해서 저장

로그인 API 연결
- bffFetch를 활용한 로그인 API 호출
- form 데이터를 request body로 전달
- 로그인 성공 시 전역 상태 업데이트

아래 파일은 서정님이 수정하신 내용이 제쪽에서도 필요해서 충돌 방지하고자 동일하게 복사하여 반영했습니다!
- coreFetch.ts
- bffFetch.ts
- serverFetch.ts
- publicFetch.ts
- message.ts

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
