### PR TITLE
[✨ Feat/#134] Next API Route 구현

### DIFF
--- a/src/app/api/activities/[activityId]/reservations/route.ts
+++ b/src/app/api/activities/[activityId]/reservations/route.ts
@@ -1,0 +1,25 @@
+import type {
+  CreateActivityReservationRequestBody,
+  MyReservationItem,
+} from '@/features/reservation/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
+
+/**
+ * ## 체험 예약 신청 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자가 체험 예약을 신청합니다.
+ *
+ * - Backend: `POST /{teamId}/activities/{activityId}/reservations`
+ *
+ * @returns 생성된 예약 (`MyReservationItem`)
+ */
+export const POST = createAuthorizedRoute<
+  CreateActivityReservationRequestBody,
+  { activityId: string }
+>(async ({ params, body }) => {
+  const { activityId } = requireParams(params);
+  return proxyFetch.post<MyReservationItem>(`/activities/${activityId}/reservations`, body);
+});

--- a/src/app/api/activities/image/route.ts
+++ b/src/app/api/activities/image/route.ts
@@ -1,0 +1,20 @@
+import type { CreateActivityImageUrlResponse } from '@/features/activity/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 체험 이미지 URL 생성 API (BFF)
+ *
+ * @description
+ * 체험 등록/수정에 사용할 이미지를 업로드하고 URL을 반환합니다.
+ *
+ * - Backend: `POST /{teamId}/activities/image`
+ * - 요청 본문: `multipart/form-data` (`image` 필드)
+ *
+ * @returns 업로드된 이미지 URL (`CreateActivityImageUrlResponse`)
+ */
+export const POST = createAuthorizedRoute<FormData>(async ({ body }) => {
+  return proxyFetch.post<CreateActivityImageUrlResponse>('/activities/image', body, {
+    isFormData: true,
+  });
+});

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,0 +1,17 @@
+import type { CreateActivityRequestBody, CreateActivityResponse } from '@/features/activity/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 체험 등록 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자가 체험을 등록합니다.
+ *
+ * - Backend: `POST /{teamId}/activities`
+ *
+ * @returns 등록된 체험 (`CreateActivityResponse`)
+ */
+export const POST = createAuthorizedRoute<CreateActivityRequestBody>(async ({ body }) => {
+  return proxyFetch.post<CreateActivityResponse>('/activities', body);
+});

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,4 +1,6 @@
 import type { CreateActivityRequestBody, CreateActivityResponse } from '@/features/activity/types';
+import { ACTIVITY_ERROR_MESSAGES } from '@/features/my-page/activity-form/constants/validation';
+import { ApiError } from '@/shared/apis/apiError';
 import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
 import { proxyFetch } from '@/shared/apis/bff/proxy';
 
@@ -13,5 +15,8 @@ import { proxyFetch } from '@/shared/apis/bff/proxy';
  * @returns 등록된 체험 (`CreateActivityResponse`)
  */
 export const POST = createAuthorizedRoute<CreateActivityRequestBody>(async ({ body }) => {
+  if (body?.title && body.title.length > 50) {
+    throw new ApiError(400, ACTIVITY_ERROR_MESSAGES.TITLE_MAX_LENGTH);
+  }
   return proxyFetch.post<CreateActivityResponse>('/activities', body);
 });

--- a/src/app/api/my-activities/[activityId]/reservation-dashboard/route.ts
+++ b/src/app/api/my-activities/[activityId]/reservation-dashboard/route.ts
@@ -1,0 +1,27 @@
+import type { GetMyActivityReservationDashboardResponse } from '@/features/my-page/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
+
+/**
+ * ## 내 체험 월별 예약 현황 조회 API (BFF)
+ *
+ * @description
+ * 내 체험의 월별 예약 현황을 조회합니다.
+ *
+ * - Backend: `GET /{teamId}/my-activities/{activityId}/reservation-dashboard`
+ *
+ * @query year YYYY
+ * @query month MM
+ *
+ * @returns 예약 현황 (`GetMyActivityReservationDashboardResponse`)
+ */
+export const GET = createAuthorizedRoute<unknown, { activityId: string }>(
+  async ({ request, params }) => {
+    const { activityId } = requireParams(params);
+    const { search } = new URL(request.url);
+    return proxyFetch.get<GetMyActivityReservationDashboardResponse>(
+      `/my-activities/${activityId}/reservation-dashboard${search}`
+    );
+  }
+);

--- a/src/app/api/my-activities/[activityId]/reservations/[reservationId]/route.ts
+++ b/src/app/api/my-activities/[activityId]/reservations/[reservationId]/route.ts
@@ -1,0 +1,29 @@
+import type {
+  UpdateMyActivityReservationStatusRequestBody,
+  UpdateMyActivityReservationStatusResponse,
+} from '@/features/my-page/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
+
+/**
+ * ## 내 체험 예약 상태 업데이트 API (BFF)
+ *
+ * @description
+ * 내 체험 예약 상태(승인/거절)를 업데이트합니다.
+ *
+ * - Backend: `PATCH /{teamId}/my-activities/{activityId}/reservations/{reservationId}`
+ *
+ * @param body `{ status: "declined" | "pending" | "confirmed" }`
+ * @returns 수정된 예약 (`UpdateMyActivityReservationStatusResponse`)
+ */
+export const PATCH = createAuthorizedRoute<
+  UpdateMyActivityReservationStatusRequestBody,
+  { activityId: string; reservationId: string }
+>(async ({ params, body }) => {
+  const { activityId, reservationId } = requireParams(params);
+  return proxyFetch.patch<UpdateMyActivityReservationStatusResponse>(
+    `/my-activities/${activityId}/reservations/${reservationId}`,
+    body
+  );
+});

--- a/src/app/api/my-activities/[activityId]/reservations/route.ts
+++ b/src/app/api/my-activities/[activityId]/reservations/route.ts
@@ -1,0 +1,29 @@
+import type { GetMyActivityReservationsResponse } from '@/features/my-page/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
+
+/**
+ * ## 내 체험 예약 시간대별 예약 내역 조회 API (BFF)
+ *
+ * @description
+ * 내 체험의 예약 목록을 조회합니다. (커서 기반 페이지네이션)
+ *
+ * - Backend: `GET /{teamId}/my-activities/{activityId}/reservations`
+ *
+ * @query cursorId 커서 ID
+ * @query size 페이지 크기 (기본 10)
+ * @query scheduleId 스케줄 ID
+ * @query status declined | pending | confirmed
+ *
+ * @returns 예약 내역 (`GetMyActivityReservationsResponse`)
+ */
+export const GET = createAuthorizedRoute<unknown, { activityId: string }>(
+  async ({ request, params }) => {
+    const { activityId } = requireParams(params);
+    const { search } = new URL(request.url);
+    return proxyFetch.get<GetMyActivityReservationsResponse>(
+      `/my-activities/${activityId}/reservations${search}`
+    );
+  }
+);

--- a/src/app/api/my-activities/[activityId]/reserved-schedule/route.ts
+++ b/src/app/api/my-activities/[activityId]/reserved-schedule/route.ts
@@ -1,0 +1,26 @@
+import type { GetMyActivityReservedScheduleResponse } from '@/features/my-page/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
+
+/**
+ * ## 내 체험 날짜별 예약 정보가 있는 스케줄 조회 API (BFF)
+ *
+ * @description
+ * 특정 날짜에 예약 정보(신청/승인/거절)가 있는 스케줄 목록을 조회합니다.
+ *
+ * - Backend: `GET /{teamId}/my-activities/{activityId}/reserved-schedule`
+ *
+ * @query date YYYY-MM-DD
+ *
+ * @returns 스케줄 목록 (`GetMyActivityReservedScheduleResponse`)
+ */
+export const GET = createAuthorizedRoute<unknown, { activityId: string }>(
+  async ({ request, params }) => {
+    const { activityId } = requireParams(params);
+    const { search } = new URL(request.url);
+    return proxyFetch.get<GetMyActivityReservedScheduleResponse>(
+      `/my-activities/${activityId}/reserved-schedule${search}`
+    );
+  }
+);

--- a/src/app/api/my-activities/[activityId]/route.ts
+++ b/src/app/api/my-activities/[activityId]/route.ts
@@ -1,7 +1,9 @@
+import { ACTIVITY_ERROR_MESSAGES } from '@/features/my-page/activity-form/constants/validation';
 import type {
   UpdateMyActivityRequestBody,
   UpdateMyActivityResponse,
 } from '@/features/my-page/types';
+import { ApiError } from '@/shared/apis/apiError';
 import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
 import { proxyFetch } from '@/shared/apis/bff/proxy';
 import { requireParams } from '@/shared/apis/bff/requireParams';
@@ -35,6 +37,9 @@ export const DELETE = createAuthorizedRoute<unknown, { activityId: string }>(asy
 export const PATCH = createAuthorizedRoute<UpdateMyActivityRequestBody, { activityId: string }>(
   async ({ params, body }) => {
     const { activityId } = requireParams(params);
+    if (body?.title && body.title.length > 50) {
+      throw new ApiError(400, ACTIVITY_ERROR_MESSAGES.TITLE_MAX_LENGTH);
+    }
     return proxyFetch.patch<UpdateMyActivityResponse>(`/my-activities/${activityId}`, body);
   }
 );

--- a/src/app/api/my-activities/[activityId]/route.ts
+++ b/src/app/api/my-activities/[activityId]/route.ts
@@ -1,0 +1,40 @@
+import type {
+  UpdateMyActivityRequestBody,
+  UpdateMyActivityResponse,
+} from '@/features/my-page/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
+
+/**
+ * ## 내 체험 삭제 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 체험을 삭제합니다.
+ *
+ * - Backend: `DELETE /{teamId}/my-activities/{activityId}`
+ *
+ * @returns 204 No Content
+ */
+export const DELETE = createAuthorizedRoute<unknown, { activityId: string }>(async ({ params }) => {
+  const { activityId } = requireParams(params);
+  await proxyFetch.delete(`/my-activities/${activityId}`);
+  return undefined;
+});
+
+/**
+ * ## 내 체험 수정 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 체험을 수정합니다.
+ *
+ * - Backend: `PATCH /{teamId}/my-activities/{activityId}`
+ *
+ * @returns 수정된 체험 (`UpdateMyActivityResponse`)
+ */
+export const PATCH = createAuthorizedRoute<UpdateMyActivityRequestBody, { activityId: string }>(
+  async ({ params, body }) => {
+    const { activityId } = requireParams(params);
+    return proxyFetch.patch<UpdateMyActivityResponse>(`/my-activities/${activityId}`, body);
+  }
+);

--- a/src/app/api/my-activities/route.ts
+++ b/src/app/api/my-activities/route.ts
@@ -1,0 +1,21 @@
+import type { GetMyActivitiesResponse } from '@/features/my-page/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 내 체험 리스트 조회 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 체험 목록을 조회합니다. (커서 기반 페이지네이션)
+ *
+ * - Backend: `GET /{teamId}/my-activities`
+ *
+ * @query cursorId 커서 ID
+ * @query size 페이지 크기 (기본 20)
+ *
+ * @returns 내 체험 리스트 (`GetMyActivitiesResponse`)
+ */
+export const GET = createAuthorizedRoute(async ({ request }) => {
+  const { search } = new URL(request.url);
+  return proxyFetch.get<GetMyActivitiesResponse>(`/my-activities${search}`);
+});

--- a/src/app/api/my-notifications/[notificationId]/route.ts
+++ b/src/app/api/my-notifications/[notificationId]/route.ts
@@ -1,0 +1,21 @@
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
+
+/**
+ * ## 내 알림 삭제 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 알림을 삭제합니다.
+ *
+ * - Backend: `DELETE /{teamId}/my-notifications/{notificationId}`
+ *
+ * @returns 204 No Content
+ */
+export const DELETE = createAuthorizedRoute<unknown, { notificationId: string }>(
+  async ({ params }) => {
+    const { notificationId } = requireParams(params);
+    await proxyFetch.delete(`/my-notifications/${notificationId}`);
+    return undefined;
+  }
+);

--- a/src/app/api/my-notifications/route.ts
+++ b/src/app/api/my-notifications/route.ts
@@ -1,0 +1,21 @@
+import type { GetMyNotificationsResponse } from '@/features/notification/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 내 알림 리스트 조회 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 알림 목록을 조회합니다. (커서 기반 페이지네이션)
+ *
+ * - Backend: `GET /{teamId}/my-notifications`
+ *
+ * @query cursorId 커서 ID
+ * @query size 페이지 크기 (기본 10)
+ *
+ * @returns 내 알림 리스트 (`GetMyNotificationsResponse`)
+ */
+export const GET = createAuthorizedRoute(async ({ request }) => {
+  const { search } = new URL(request.url);
+  return proxyFetch.get<GetMyNotificationsResponse>(`/my-notifications${search}`);
+});

--- a/src/app/api/my-reservations/[reservationId]/application/route.ts
+++ b/src/app/api/my-reservations/[reservationId]/application/route.ts
@@ -4,6 +4,7 @@ import type {
 } from '@/features/reservation/types';
 import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
 import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
 
 /**
  * ## 체험 예약 신청 변경 API (BFF)
@@ -20,6 +21,6 @@ export const PATCH = createAuthorizedRoute<
   UpdateMyReservationApplicationRequestBody,
   { reservationId: string }
 >(async ({ params, body }) => {
-  const reservationId = params!.reservationId;
+  const { reservationId } = requireParams(params);
   return proxyFetch.patch<MyReservationItem>(`/my-reservations/${reservationId}/application`, body);
 });

--- a/src/app/api/my-reservations/[reservationId]/application/route.ts
+++ b/src/app/api/my-reservations/[reservationId]/application/route.ts
@@ -1,0 +1,25 @@
+import type {
+  MyReservationItem,
+  UpdateMyReservationApplicationRequestBody,
+} from '@/features/reservation/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 체험 예약 신청 변경 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 예약 신청 정보를 변경합니다.
+ *
+ * - Backend: `PATCH /{teamId}/my-reservations/{reservationId}/application`
+ *
+ * @param body `{ scheduleId, headCount }`
+ * @returns 수정된 예약 (`MyReservationItem`)
+ */
+export const PATCH = createAuthorizedRoute<
+  UpdateMyReservationApplicationRequestBody,
+  { reservationId: string }
+>(async ({ params, body }) => {
+  const reservationId = params!.reservationId;
+  return proxyFetch.patch<MyReservationItem>(`/my-reservations/${reservationId}/application`, body);
+});

--- a/src/app/api/my-reservations/[reservationId]/reviews/route.ts
+++ b/src/app/api/my-reservations/[reservationId]/reviews/route.ts
@@ -1,0 +1,28 @@
+import type {
+  CreateMyReservationReviewRequestBody,
+  CreateMyReservationReviewResponse,
+} from '@/features/reservation/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 내 예약 리뷰 작성 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자가 예약에 대한 리뷰를 작성합니다.
+ *
+ * - Backend: `POST /{teamId}/my-reservations/{reservationId}/reviews`
+ *
+ * @param body `{ rating, content }`
+ * @returns 생성된 리뷰 (`CreateMyReservationReviewResponse`)
+ */
+export const POST = createAuthorizedRoute<
+  CreateMyReservationReviewRequestBody,
+  { reservationId: string }
+>(async ({ params, body }) => {
+  const reservationId = params!.reservationId;
+  return proxyFetch.post<CreateMyReservationReviewResponse>(
+    `/my-reservations/${reservationId}/reviews`,
+    body
+  );
+});

--- a/src/app/api/my-reservations/[reservationId]/reviews/route.ts
+++ b/src/app/api/my-reservations/[reservationId]/reviews/route.ts
@@ -4,6 +4,7 @@ import type {
 } from '@/features/reservation/types';
 import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
 import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
 
 /**
  * ## 내 예약 리뷰 작성 API (BFF)
@@ -20,7 +21,7 @@ export const POST = createAuthorizedRoute<
   CreateMyReservationReviewRequestBody,
   { reservationId: string }
 >(async ({ params, body }) => {
-  const reservationId = params!.reservationId;
+  const { reservationId } = requireParams(params);
   return proxyFetch.post<CreateMyReservationReviewResponse>(
     `/my-reservations/${reservationId}/reviews`,
     body

--- a/src/app/api/my-reservations/[reservationId]/route.ts
+++ b/src/app/api/my-reservations/[reservationId]/route.ts
@@ -1,0 +1,25 @@
+import type {
+  CancelMyReservationRequestBody,
+  MyReservationItem,
+} from '@/features/reservation/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 내 예약 수정(취소) API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 예약을 취소합니다.
+ *
+ * - Backend: `PATCH /{teamId}/my-reservations/{reservationId}`
+ *
+ * @param body `{ status: "canceled" }`
+ * @returns 수정된 예약 (`MyReservationItem`)
+ */
+export const PATCH = createAuthorizedRoute<
+  CancelMyReservationRequestBody,
+  { reservationId: string }
+>(async ({ params, body }) => {
+  const reservationId = params!.reservationId;
+  return proxyFetch.patch<MyReservationItem>(`/my-reservations/${reservationId}`, body);
+});

--- a/src/app/api/my-reservations/[reservationId]/route.ts
+++ b/src/app/api/my-reservations/[reservationId]/route.ts
@@ -4,6 +4,7 @@ import type {
 } from '@/features/reservation/types';
 import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
 import { proxyFetch } from '@/shared/apis/bff/proxy';
+import { requireParams } from '@/shared/apis/bff/requireParams';
 
 /**
  * ## 내 예약 수정(취소) API (BFF)
@@ -20,6 +21,6 @@ export const PATCH = createAuthorizedRoute<
   CancelMyReservationRequestBody,
   { reservationId: string }
 >(async ({ params, body }) => {
-  const reservationId = params!.reservationId;
+  const { reservationId } = requireParams(params);
   return proxyFetch.patch<MyReservationItem>(`/my-reservations/${reservationId}`, body);
 });

--- a/src/app/api/my-reservations/route.ts
+++ b/src/app/api/my-reservations/route.ts
@@ -1,0 +1,22 @@
+import type { GetMyReservationsResponse } from '@/features/reservation/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 내 예약 리스트 조회 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 예약 내역을 조회합니다. (커서 기반 페이지네이션)
+ *
+ * - Backend: `GET /{teamId}/my-reservations`
+ *
+ * @query cursorId 커서 ID
+ * @query size 페이지 크기 (기본 10)
+ * @query status 예약 상태 필터
+ *
+ * @returns 내 예약 리스트 (`GetMyReservationsResponse`)
+ */
+export const GET = createAuthorizedRoute(async ({ request }) => {
+  const { search } = new URL(request.url);
+  return proxyFetch.get<GetMyReservationsResponse>(`/my-reservations${search}`);
+});

--- a/src/app/api/users/me/image/route.ts
+++ b/src/app/api/users/me/image/route.ts
@@ -1,0 +1,20 @@
+import type { CreateMyProfileImageUrlResponse } from '@/features/user/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 프로필 이미지 URL 생성 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 프로필 이미지를 업로드하고, 접근 가능한 URL을 반환합니다.
+ *
+ * - Backend: `POST /{teamId}/users/me/image`
+ * - 요청 본문: `multipart/form-data` (`image` 필드)
+ *
+ * @returns 생성된 프로필 이미지 URL (`CreateMyProfileImageUrlResponse`)
+ */
+export const POST = createAuthorizedRoute<FormData>(async ({ body }) => {
+  return proxyFetch.post<CreateMyProfileImageUrlResponse>('/users/me/image', body, {
+    isFormData: true,
+  });
+});

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,45 @@
+import type { UpdateMyProfileRequestBody, UserResponse } from '@/features/user/types';
+import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
+import { proxyFetch } from '@/shared/apis/bff/proxy';
+
+/**
+ * ## 내 정보 조회 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 정보를 조회합니다.
+ *
+ * - Backend: `GET /{teamId}/users/me`
+ *
+ * - 인증이 필요한 API로, `createAuthorizedRoute`를 통해 access token 존재 여부를 검사합니다.
+ * - 실제 데이터 조회는 `proxyFetch`가 백엔드 API(`/users/me`)로 요청을 전달하며,
+ *   쿠키의 `accessToken`을 `Authorization: Bearer ...` 헤더로 주입합니다.
+ *
+ * @returns 사용자 정보 (`UserResponse`)
+ */
+export const GET = createAuthorizedRoute(async ({ accessToken }) => {
+  void accessToken;
+  return proxyFetch.get<UserResponse>('/users/me');
+});
+
+/**
+ * ## 내 정보 수정 API (BFF)
+ *
+ * @description
+ * 로그인한 사용자의 정보를 수정합니다.
+ *
+ * - Backend: `PATCH /{teamId}/users/me`
+ *
+ * - 인증이 필요한 API로, `createAuthorizedRoute`를 통해 access token 존재 여부를 검사합니다.
+ * - 요청 본문은 JSON으로 파싱되며(`createAuthorizedRoute` 내부), `proxyFetch`를 통해
+ *   백엔드 API(`/users/me`)로 전달됩니다.
+ * - `proxyFetch`가 쿠키의 `accessToken`을 `Authorization: Bearer ...` 헤더로 주입합니다.
+ *
+ * @param body 수정할 사용자 정보 (`UpdateMyProfileRequestBody`)
+ * @returns 수정된 사용자 정보 (`UserResponse`)
+ */
+export const PATCH = createAuthorizedRoute<UpdateMyProfileRequestBody>(
+  async ({ accessToken, body }) => {
+    void accessToken;
+    return proxyFetch.patch<UserResponse>('/users/me', body);
+  }
+);

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -16,8 +16,7 @@ import { proxyFetch } from '@/shared/apis/bff/proxy';
  *
  * @returns 사용자 정보 (`UserResponse`)
  */
-export const GET = createAuthorizedRoute(async ({ accessToken }) => {
-  void accessToken;
+export const GET = createAuthorizedRoute(async () => {
   return proxyFetch.get<UserResponse>('/users/me');
 });
 

--- a/src/features/activity/types.ts
+++ b/src/features/activity/types.ts
@@ -1,0 +1,51 @@
+export type CreateActivityRequestBody = {
+  title: string;
+  category: string;
+  description: string;
+  address: string;
+  price: number;
+  schedules: Array<{
+    date: string;
+    startTime: string;
+    endTime: string;
+  }>;
+  bannerImageUrl: string;
+  subImageUrls: string[];
+};
+
+export type ActivitySubImage = {
+  imageUrl: string;
+  id: number;
+};
+
+export type ActivityScheduleTime = {
+  endTime: string;
+  startTime: string;
+  id: number;
+};
+
+export type ActivitySchedule = {
+  times: ActivityScheduleTime[];
+  date: string;
+};
+
+export type CreateActivityResponse = {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+  subImages: ActivitySubImage[];
+  schedules: ActivitySchedule[];
+};
+
+export type CreateActivityImageUrlResponse = {
+  activityImageUrl: string;
+};

--- a/src/features/my-page/types.ts
+++ b/src/features/my-page/types.ts
@@ -73,7 +73,7 @@ export type MyActivityReservation = {
   teamId: string;
   activityId: number;
   scheduleId: number;
-  status: string;
+  status: SellerReservationStatus;
   reviewSubmitted: boolean;
   totalPrice: number;
   headCount: number;
@@ -100,7 +100,7 @@ export type UpdateMyActivityReservationStatusResponse = {
   userId: number;
   activityId: number;
   scheduleId: number;
-  status: string;
+  status: SellerReservationStatus;
   reviewSubmitted: boolean;
   totalPrice: number;
   headCount: number;

--- a/src/features/my-page/types.ts
+++ b/src/features/my-page/types.ts
@@ -1,0 +1,158 @@
+export type GetMyActivitiesQuery = {
+  cursorId?: number;
+  size?: number;
+};
+
+export type MyActivitySummary = {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type GetMyActivitiesResponse = {
+  cursorId: number;
+  totalCount: number;
+  activities: MyActivitySummary[];
+};
+
+export type GetMyActivityReservationDashboardQuery = {
+  year: string;
+  month: string;
+};
+
+export type MyActivityReservationDashboardItem = {
+  date: string;
+  reservations: {
+    completed: number;
+    confirmed: number;
+    pending: number;
+  };
+};
+
+export type GetMyActivityReservationDashboardResponse = MyActivityReservationDashboardItem[];
+
+export type GetMyActivityReservedScheduleQuery = {
+  date: string;
+};
+
+export type MyActivityReservedScheduleItem = {
+  scheduleId: number;
+  startTime: string;
+  endTime: string;
+  count: {
+    declined: number;
+    confirmed: number;
+    pending: number;
+  };
+};
+
+export type GetMyActivityReservedScheduleResponse = MyActivityReservedScheduleItem[];
+
+export type SellerReservationStatus = 'declined' | 'pending' | 'confirmed';
+
+export type GetMyActivityReservationsQuery = {
+  cursorId?: number;
+  size?: number;
+  scheduleId: number;
+  status: SellerReservationStatus;
+};
+
+export type MyActivityReservation = {
+  id: number;
+  nickname: string;
+  userId: number;
+  teamId: string;
+  activityId: number;
+  scheduleId: number;
+  status: string;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type GetMyActivityReservationsResponse = {
+  cursorId: number;
+  totalCount: number;
+  reservations: MyActivityReservation[];
+};
+
+export type UpdateMyActivityReservationStatusRequestBody = {
+  status: SellerReservationStatus;
+};
+
+export type UpdateMyActivityReservationStatusResponse = {
+  id: number;
+  teamId: string;
+  userId: number;
+  activityId: number;
+  scheduleId: number;
+  status: string;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DeleteMyActivityResponse = undefined;
+
+export type UpdateMyActivityRequestBody = {
+  title: string;
+  category: string;
+  description: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  subImageIdsToRemove: number[];
+  subImageUrlsToAdd: string[];
+  scheduleIdsToRemove: number[];
+  schedulesToAdd: Array<{
+    date: string;
+    startTime: string;
+    endTime: string;
+  }>;
+};
+
+export type UpdateMyActivityResponse = {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+  subImages: Array<{
+    imageUrl: string;
+    id: number;
+  }>;
+  schedules: Array<{
+    times: Array<{
+      endTime: string;
+      startTime: string;
+      id: number;
+    }>;
+    date: string;
+  }>;
+};

--- a/src/features/notification/types.ts
+++ b/src/features/notification/types.ts
@@ -1,0 +1,20 @@
+export type GetMyNotificationsQuery = {
+  cursorId?: number;
+  size?: number;
+};
+
+export type MyNotification = {
+  id: number;
+  teamId: string;
+  userId: number;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+};
+
+export type GetMyNotificationsResponse = {
+  cursorId: number;
+  notifications: MyNotification[];
+  totalCount: number;
+};

--- a/src/features/reservation/types.ts
+++ b/src/features/reservation/types.ts
@@ -1,0 +1,78 @@
+export type MyReservationStatus = 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed';
+
+export type GetMyReservationsQuery = {
+  cursorId?: number;
+  size?: number;
+  status?: MyReservationStatus;
+};
+
+export type MyReservationActivitySummary = {
+  bannerImageUrl: string;
+  title: string;
+  id: number;
+};
+
+export type MyReservation = {
+  id: number;
+  teamId: string;
+  userId: number;
+  activity: MyReservationActivitySummary;
+  scheduleId: number;
+  status: MyReservationStatus;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type GetMyReservationsResponse = {
+  cursorId: number;
+  reservations: MyReservation[];
+  totalCount: number;
+};
+
+export type CancelMyReservationRequestBody = {
+  status: 'canceled';
+};
+
+export type UpdateMyReservationApplicationRequestBody = {
+  scheduleId: number;
+  headCount: number;
+};
+
+export type MyReservationItem = {
+  id: number;
+  teamId: string;
+  userId: number;
+  activityId: number;
+  scheduleId: number;
+  status: MyReservationStatus;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateMyReservationReviewRequestBody = {
+  rating: number;
+  content: string;
+};
+
+export type CreateMyReservationReviewResponse = {
+  updatedAt: string;
+  createdAt: string;
+  content: string;
+  rating: number;
+  userId: number;
+  activityId: number;
+  teamId: string;
+  id: number;
+};

--- a/src/features/reservation/types.ts
+++ b/src/features/reservation/types.ts
@@ -76,3 +76,8 @@ export type CreateMyReservationReviewResponse = {
   teamId: string;
   id: number;
 };
+
+export type CreateActivityReservationRequestBody = {
+  scheduleId: number;
+  headCount: number;
+};

--- a/src/features/user/types.ts
+++ b/src/features/user/types.ts
@@ -6,3 +6,13 @@ export type UserResponse = {
   createdAt: string;
   updatedAt: string;
 };
+
+export type UpdateMyProfileRequestBody = {
+  nickname?: string;
+  profileImageUrl?: string;
+  newPassword?: string;
+};
+
+export type CreateMyProfileImageUrlResponse = {
+  profileImageUrl: string;
+};

--- a/src/shared/apis/base/coreFetch.ts
+++ b/src/shared/apis/base/coreFetch.ts
@@ -40,6 +40,11 @@ export type FetchRequestOptions = RequestInit & {
   isFormData?: boolean;
 };
 
+const isAbortError = (error: unknown): error is { name: 'AbortError' } => {
+  const errorName = (error as { name?: unknown } | null)?.name;
+  return errorName === 'AbortError';
+};
+
 export type RequestConfig = {
   endpoint: string;
   method: RequestInit['method'];
@@ -90,7 +95,11 @@ export async function coreFetch<T>(
   const { isFormData = false, ...requestOptions } = options;
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
+  let abortedByTimeout = false;
+  const timeoutId = setTimeout(() => {
+    abortedByTimeout = true;
+    controller.abort();
+  }, REQUEST_TIMEOUT);
   const signal = options.signal
     ? AbortSignal.any([controller.signal, options.signal])
     : controller.signal;
@@ -126,16 +135,15 @@ export async function coreFetch<T>(
     // Fetch 자체 실패(네트워크/타임아웃 abort 등)는 네트워크 에러 메세지로 통일
     if (error instanceof ApiError) throw error;
 
-    const errorName = (error as { name?: unknown } | null)?.name;
-    if (errorName === 'AbortError') {
-      throw new ApiError(408, COMMON_MESSAGE.ERROR.NETWORK);
+    if (isAbortError(error)) {
+      if (abortedByTimeout) {
+        throw new Error(COMMON_MESSAGE.ERROR.NETWORK);
+      }
+      // 외부 취소(라우트 변경, 수동 abort 등)
+      throw new Error('요청이 취소되었습니다.');
     }
 
-    if (error instanceof TypeError) {
-      throw new ApiError(503, COMMON_MESSAGE.ERROR.NETWORK);
-    }
-
-    throw error;
+    throw new ApiError(500, COMMON_MESSAGE.ERROR.INTERNAL);
   } finally {
     clearTimeout(timeoutId);
   }

--- a/src/shared/apis/bff/createAuthorizedRoute.ts
+++ b/src/shared/apis/bff/createAuthorizedRoute.ts
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers';
+import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { ApiError } from '@/shared/apis/apiError';
 import { COMMON_MESSAGE } from '@/shared/constants/message';
@@ -87,8 +88,8 @@ export const createAuthorizedRoute = <
 >(
   handler: (ctx: AuthorizedHandlerContextWithParams<TBody, TParams>) => Promise<unknown>,
   options: CreateAuthorizedRouteOptions = {}
-): ((request: Request, context?: { params?: TParams }) => Promise<Response>) => {
-  return async (request: Request, context?: { params?: TParams }) => {
+): ((request: NextRequest, context?: { params?: Promise<TParams> }) => Promise<Response>) => {
+  return async (request: NextRequest, context?: { params?: Promise<TParams> }) => {
     const cookieStore = await cookies();
     const accessTokenCookieKey = options.accessTokenCookieKey ?? 'accessToken';
     const accessToken = cookieStore.get(accessTokenCookieKey)?.value;
@@ -102,12 +103,13 @@ export const createAuthorizedRoute = <
 
     try {
       const body = (await parseRequestBody(request)) as TBody;
+      const params = await context?.params;
 
       const result = await handler({
         accessToken,
         body,
         request,
-        params: context?.params,
+        params,
       });
 
       if (result instanceof Response) return result;

--- a/src/shared/apis/bff/createAuthorizedRoute.ts
+++ b/src/shared/apis/bff/createAuthorizedRoute.ts
@@ -51,7 +51,12 @@ const parseRequestBody = async (request: Request): Promise<unknown> => {
   if (contentType.includes('application/json')) {
     // body가 비어있을 때 request.json()이 throw할 수 있어 text 기반 파싱 사용
     const text = await request.text();
-    return text ? (JSON.parse(text) as unknown) : undefined;
+    if (!text) return undefined;
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      throw new ApiError(400, '요청 본문이 올바른 JSON 형식이 아닙니다.');
+    }
   }
 
   return undefined;
@@ -82,8 +87,8 @@ export const createAuthorizedRoute = <
 >(
   handler: (ctx: AuthorizedHandlerContextWithParams<TBody, TParams>) => Promise<unknown>,
   options: CreateAuthorizedRouteOptions = {}
-) => {
-  return async (request: Request, context?: { params?: RouteHandlerParams }) => {
+): ((request: Request, context?: { params?: TParams }) => Promise<Response>) => {
+  return async (request: Request, context?: { params?: TParams }) => {
     const cookieStore = await cookies();
     const accessTokenCookieKey = options.accessTokenCookieKey ?? 'accessToken';
     const accessToken = cookieStore.get(accessTokenCookieKey)?.value;
@@ -102,7 +107,7 @@ export const createAuthorizedRoute = <
         accessToken,
         body,
         request,
-        params: context?.params as TParams | undefined,
+        params: context?.params,
       });
 
       if (result instanceof Response) return result;

--- a/src/shared/apis/bff/createAuthorizedRoute.ts
+++ b/src/shared/apis/bff/createAuthorizedRoute.ts
@@ -17,6 +17,15 @@ export type AuthorizedHandlerContext<TBody = unknown> = {
   request: Request;
 };
 
+export type RouteHandlerParams = Record<string, string | string[]>;
+
+export type AuthorizedHandlerContextWithParams<
+  TBody = unknown,
+  TParams extends RouteHandlerParams = RouteHandlerParams,
+> = AuthorizedHandlerContext<TBody> & {
+  params?: TParams;
+};
+
 type CreateAuthorizedRouteOptions = {
   /**
    * accessToken 쿠키가 없을 때 반환할 메시지
@@ -62,15 +71,19 @@ const parseRequestBody = async (request: Request): Promise<unknown> => {
  * - handler 실행 중 발생한 에러를 HTTP Response로 변환합니다.
  *
  * @template TBody - handler에서 사용할 요청 body 타입
+ * @template TParams - handler에서 사용할 params 타입 (동적 라우트용)
  * @param handler - 인증 및 body 파싱이 완료된 후 실행될 함수
  * @param options - 쿠키 키/401 메시지 커스터마이징 옵션
  * @returns - Next.js Route Handler 함수
  */
-export const createAuthorizedRoute = <TBody = unknown>(
-  handler: (ctx: AuthorizedHandlerContext<TBody>) => Promise<unknown>,
+export const createAuthorizedRoute = <
+  TBody = unknown,
+  TParams extends RouteHandlerParams = RouteHandlerParams,
+>(
+  handler: (ctx: AuthorizedHandlerContextWithParams<TBody, TParams>) => Promise<unknown>,
   options: CreateAuthorizedRouteOptions = {}
 ) => {
-  return async (request: Request) => {
+  return async (request: Request, context?: { params?: RouteHandlerParams }) => {
     const cookieStore = await cookies();
     const accessTokenCookieKey = options.accessTokenCookieKey ?? 'accessToken';
     const accessToken = cookieStore.get(accessTokenCookieKey)?.value;
@@ -89,6 +102,7 @@ export const createAuthorizedRoute = <TBody = unknown>(
         accessToken,
         body,
         request,
+        params: context?.params as TParams | undefined,
       });
 
       if (result instanceof Response) return result;

--- a/src/shared/apis/bff/createAuthorizedRoute.ts
+++ b/src/shared/apis/bff/createAuthorizedRoute.ts
@@ -1,0 +1,109 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { ApiError } from '@/shared/apis/apiError';
+import { COMMON_MESSAGE } from '@/shared/constants/message';
+
+/**
+ * 인증이 필요한 Route Handler에서 handler로 전달되는 컨텍스트 타입
+ *
+ * @template TBody - 요청 body의 타입 (JSON, FormData 등)
+ * @property accessToken - 인증된 사용자의 access token
+ * @property body - HTTP 요청 body (GET/DELETE에서는 undefined)
+ * @property request - 원본 Request 객체
+ */
+export type AuthorizedHandlerContext<TBody = unknown> = {
+  accessToken: string;
+  body?: TBody;
+  request: Request;
+};
+
+type CreateAuthorizedRouteOptions = {
+  /**
+   * accessToken 쿠키가 없을 때 반환할 메시지
+   * (기본값: COMMON_MESSAGE.ERROR.UNAUTHORIZED)
+   */
+  unauthorizedMessage?: string;
+  /**
+   * accessToken을 읽어올 쿠키 키
+   * (기본값: 'accessToken')
+   */
+  accessTokenCookieKey?: string;
+};
+
+const parseRequestBody = async (request: Request): Promise<unknown> => {
+  if (request.method === 'GET' || request.method === 'DELETE') return undefined;
+
+  const contentType = request.headers.get('content-type') ?? '';
+
+  if (contentType.includes('multipart/form-data')) {
+    return request.formData();
+  }
+
+  if (contentType.includes('application/json')) {
+    // body가 비어있을 때 request.json()이 throw할 수 있어 text 기반 파싱 사용
+    const text = await request.text();
+    return text ? (JSON.parse(text) as unknown) : undefined;
+  }
+
+  return undefined;
+};
+
+/**
+ * ## createAuthorizedRoute
+ *
+ * @description
+ * 인증이 필요한 Next.js Route Handler를 생성하는 고차 함수입니다.
+ * - 쿠키에서 accessToken 존재 여부를 검사합니다.
+ * - HTTP 메서드에 따라 요청 body를 안전하게 파싱합니다.
+ *   - `GET`, `DELETE` → body 파싱하지 않음
+ *   - 그 외 메서드
+ *     - `multipart/form-data` → `request.formData()`
+ *     - `application/json` → 빈 body를 고려하여 text 파싱
+ * - handler 실행 중 발생한 에러를 HTTP Response로 변환합니다.
+ *
+ * @template TBody - handler에서 사용할 요청 body 타입
+ * @param handler - 인증 및 body 파싱이 완료된 후 실행될 함수
+ * @param options - 쿠키 키/401 메시지 커스터마이징 옵션
+ * @returns - Next.js Route Handler 함수
+ */
+export const createAuthorizedRoute = <TBody = unknown>(
+  handler: (ctx: AuthorizedHandlerContext<TBody>) => Promise<unknown>,
+  options: CreateAuthorizedRouteOptions = {}
+) => {
+  return async (request: Request) => {
+    const cookieStore = await cookies();
+    const accessTokenCookieKey = options.accessTokenCookieKey ?? 'accessToken';
+    const accessToken = cookieStore.get(accessTokenCookieKey)?.value;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { message: options.unauthorizedMessage ?? COMMON_MESSAGE.ERROR.UNAUTHORIZED },
+        { status: 401 }
+      );
+    }
+
+    try {
+      const body = (await parseRequestBody(request)) as TBody;
+
+      const result = await handler({
+        accessToken,
+        body,
+        request,
+      });
+
+      if (result instanceof Response) return result;
+
+      if (result === undefined) {
+        return new NextResponse(null, { status: 204 });
+      }
+
+      return NextResponse.json(result);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return NextResponse.json({ message: error.message }, { status: error.status });
+      }
+
+      return NextResponse.json({ message: COMMON_MESSAGE.ERROR.INTERNAL }, { status: 500 });
+    }
+  };
+};

--- a/src/shared/apis/bff/requireParams.ts
+++ b/src/shared/apis/bff/requireParams.ts
@@ -1,0 +1,8 @@
+/**
+ * 동적 라우트 handler에서 params를 안전하게 강제하기 위한 유틸리티입니다.
+ * (createAuthorizedRoute의 ctx.params는 정적/동적 라우트 공용 시그니처를 위해 optional)
+ */
+export const requireParams = <T>(params: T | undefined): T => {
+  if (!params) throw new Error('Route params are missing.');
+  return params;
+};

--- a/src/shared/constants/message.ts
+++ b/src/shared/constants/message.ts
@@ -1,5 +1,7 @@
 export const COMMON_MESSAGE = {
   ERROR: {
     NETWORK: '네트워크 오류가 발생했습니다.',
+    INTERNAL: '일시적인 오류가 발생했습니다.',
+    UNAUTHORIZED: '로그인이 필요합니다.',
   },
 } as const;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #134 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### Next API Route
BFF 구조로 관리되어야 할 API 구현했습니다
Activities (체험 등록, 체험 예약 신청, 체험 이미지 url 생성)
MyActivities (전체)
MyNotifications (전체)
MyReservations (전체)
Users(내 정보 조회, 내 정보 수정, 프로필 이미지 url 생성)

features에서 사용하실 때 예시
`bffFetch.post<CreateActivityResponse>('/activities', body)`

### createAuthorizedRoute
인증이 필요한 Route Handler에서 공통으로 사용할 수 있도록 createAuthorizedRoute를 구현했습니다

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
