### PR TITLE
[✨ Feat/#152] 예약 내역 페이지 퍼블리싱 및 API 연결

### DIFF
--- a/src/app/(private)/mypage/reservation-list/page.tsx
+++ b/src/app/(private)/mypage/reservation-list/page.tsx
@@ -1,3 +1,5 @@
+import ReservationListView from '@/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView';
+
 export default function ReservationListPage() {
-  return <div>마이페이지 - 예약 내역 리스트 페이지입니다.</div>;
+  return <ReservationListView />;
 }

--- a/src/features/reservation/apis.ts
+++ b/src/features/reservation/apis.ts
@@ -1,9 +1,9 @@
 import { bffFetch } from '@/shared/apis/base/bffFetch';
 import { GetMyReservationsResponseSchema } from './types';
-import type { GetMyReservationsQuery, GetMyReservationsResponse } from './types';
+import type { GetMyReservationsQuery } from './types';
 
 export const getMyReservations = async (query?: GetMyReservationsQuery) => {
   const data = await bffFetch.get<unknown>('/my-reservations', query);
   if (!data) return null;
-  return GetMyReservationsResponseSchema.parse(data) as GetMyReservationsResponse;
+  return GetMyReservationsResponseSchema.parse(data);
 };

--- a/src/features/reservation/apis.ts
+++ b/src/features/reservation/apis.ts
@@ -1,0 +1,9 @@
+import { bffFetch } from '@/shared/apis/base/bffFetch';
+import { GetMyReservationsResponseSchema } from './types';
+import type { GetMyReservationsQuery, GetMyReservationsResponse } from './types';
+
+export const getMyReservations = async (query?: GetMyReservationsQuery) => {
+  const data = await bffFetch.get<unknown>('/my-reservations', query);
+  if (!data) return null;
+  return GetMyReservationsResponseSchema.parse(data) as GetMyReservationsResponse;
+};

--- a/src/features/reservation/reservation-list/queries/useMyReservations.ts
+++ b/src/features/reservation/reservation-list/queries/useMyReservations.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyReservations } from '@/features/reservation/apis';
+import type { GetMyReservationsResponse, MyReservationStatus } from '@/features/reservation/types';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
+
+type UseMyReservationsParams = {
+  status?: MyReservationStatus;
+  size?: number;
+};
+
+const EMPTY_RESPONSE: GetMyReservationsResponse = {
+  cursorId: null,
+  reservations: [],
+  totalCount: 0,
+};
+
+export const useMyReservations = ({ status, size = 10 }: UseMyReservationsParams = {}) => {
+  return useQuery({
+    queryKey: QUERY_KEYS.MY_RESERVATIONS(status, size),
+    queryFn: async () =>
+      (await getMyReservations({
+        size,
+        status,
+      })) ?? EMPTY_RESPONSE,
+    // TODO: 무한 스크롤 적용 시 useInfiniteQuery + getNextPageParam로 교체
+  });
+};

--- a/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListSection.tsx
+++ b/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListSection.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useMemo } from 'react';
+import ReservationCard from '@/features/reservation/reservation-list/ui/reservation-card/ReservationCard';
+import type { MyReservation } from '@/features/reservation/types';
+import EmptyState from '@/shared/ui/empty-state/EmptyState';
+import Loading from '@/shared/ui/loading/Loading';
+import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
+
+type ReservationListSectionProps = {
+  isLoading: boolean;
+  reservations: MyReservation[];
+  selectedStatus: ReservationStatus | '';
+  emptyMainTextByStatus: Record<ReservationStatus | '', string>;
+};
+
+const formatReservationDate = (value: string) => {
+  const [year, month, day] = value.split('-');
+  if (!year || !month || !day) return value;
+  return `${year}. ${month.padStart(2, '0')}. ${day.padStart(2, '0')}`;
+};
+
+export default function ReservationListSection({
+  isLoading,
+  reservations,
+  selectedStatus,
+  emptyMainTextByStatus,
+}: ReservationListSectionProps) {
+  const reservationsByDate = useMemo(() => {
+    const group: Record<string, MyReservation[]> = {};
+    const dateOrder: string[] = [];
+
+    reservations.forEach((item) => {
+      if (!group[item.date]) {
+        group[item.date] = [];
+        dateOrder.push(item.date);
+      }
+      group[item.date].push(item);
+    });
+
+    return dateOrder.map((date) => ({ date, items: group[date] }));
+  }, [reservations]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        {/* TODO: 예약내역 로딩 스켈레톤 UI로 교체 */}
+        <Loading />
+      </div>
+    );
+  }
+
+  if (reservations.length === 0) {
+    return (
+      <EmptyState
+        type="experience"
+        mainText={emptyMainTextByStatus[selectedStatus]}
+        button={{ href: '/activities', text: '둘러보기' }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-7.5">
+      {reservationsByDate.map(({ date, items }, index) => (
+        <section key={date} className="flex flex-col gap-3">
+          <p className="typo-16-bold text-gray-800">{formatReservationDate(date)}</p>
+          <div className="flex flex-col gap-7.5">
+            {items.map((reservation) => (
+              <ReservationCard key={reservation.id} data={reservation} />
+            ))}
+          </div>
+          {index !== reservationsByDate.length - 1 && <div className="mt-5 h-px bg-gray-50" />}
+        </section>
+      ))}
+
+      {/* TODO: 무한 스크롤 적용 */}
+    </div>
+  );
+}

--- a/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListSection.tsx
+++ b/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListSection.tsx
@@ -6,18 +6,13 @@ import type { MyReservation } from '@/features/reservation/types';
 import EmptyState from '@/shared/ui/empty-state/EmptyState';
 import Loading from '@/shared/ui/loading/Loading';
 import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
+import { formatYmdToDot } from '@/shared/utils/dateFormat';
 
 type ReservationListSectionProps = {
   isLoading: boolean;
   reservations: MyReservation[];
   selectedStatus: ReservationStatus | '';
   emptyMainTextByStatus: Record<ReservationStatus | '', string>;
-};
-
-const formatReservationDate = (value: string) => {
-  const [year, month, day] = value.split('-');
-  if (!year || !month || !day) return value;
-  return `${year}. ${month.padStart(2, '0')}. ${day.padStart(2, '0')}`;
 };
 
 export default function ReservationListSection({
@@ -64,7 +59,7 @@ export default function ReservationListSection({
     <div className="flex flex-col gap-7.5">
       {reservationsByDate.map(({ date, items }, index) => (
         <section key={date} className="flex flex-col gap-3">
-          <p className="typo-16-bold text-gray-800">{formatReservationDate(date)}</p>
+          <p className="typo-16-bold text-gray-800">{formatYmdToDot(date)}</p>
           <div className="flex flex-col gap-7.5">
             {items.map((reservation) => (
               <ReservationCard key={reservation.id} data={reservation} />

--- a/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
+++ b/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
@@ -3,11 +3,11 @@
 import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import { useMyReservations } from '@/features/reservation/reservation-list/queries/useMyReservations';
+import ReservationListSection from '@/features/reservation/reservation-list/ui/my-reservation-list/ReservationListSection';
+import StatusFilter from '@/features/reservation/reservation-list/ui/status-filter/StatusFilter';
 import type { MyReservationStatus } from '@/features/reservation/types';
 import PageHeader from '@/shared/ui/page-header/PageHeader';
 import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
-import StatusFilter from '../status-filter/StatusFilter';
-import ReservationListSection from './ReservationListSection';
 
 export default function ReservationListView() {
   const router = useRouter();

--- a/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
+++ b/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
@@ -12,9 +12,9 @@ import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 const EMPTY_MAIN_TEXT_BY_STATUS: Record<ReservationStatus | '', string> = {
   '': '아직 예약한 체험이 없어요.\n새로운 체험을 예약해보세요!',
   pending: '예약 완료 내역이 없습니다.\n새로운 체험을 예약해보세요!',
-  declined: '아직 취소된 내역이 없어요.',
+  declined: '아직 거절된 내역이 없어요.',
   confirmed: '아직 승인된 내역이 없어요.',
-  canceled: '아직 거절된 내역이 없어요.',
+  canceled: '아직 취소된 내역이 없어요.',
   completed: '아직 완료된 내역이 없어요.',
 };
 

--- a/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
+++ b/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
@@ -9,6 +9,15 @@ import type { MyReservationStatus } from '@/features/reservation/types';
 import PageHeader from '@/shared/ui/page-header/PageHeader';
 import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 
+const EMPTY_MAIN_TEXT_BY_STATUS: Record<ReservationStatus | '', string> = {
+  '': '아직 예약한 체험이 없어요.\n새로운 체험을 예약해보세요!',
+  pending: '예약 완료 내역이 없습니다.\n새로운 체험을 예약해보세요!',
+  declined: '아직 취소된 내역이 없어요.',
+  confirmed: '아직 승인된 내역이 없어요.',
+  canceled: '아직 거절된 내역이 없어요.',
+  completed: '아직 완료된 내역이 없어요.',
+};
+
 export default function ReservationListView() {
   const router = useRouter();
   const [selectedStatus, setSelectedStatus] = useState<ReservationStatus | ''>('pending');
@@ -21,15 +30,6 @@ export default function ReservationListView() {
   const reservations = useMemo(() => {
     return data?.reservations ?? [];
   }, [data?.reservations]);
-
-  const EMPTY_MAIN_TEXT_BY_STATUS: Record<ReservationStatus | '', string> = {
-    '': '아직 예약한 체험이 없어요.\n새로운 체험을 예약해보세요!',
-    pending: '예약 완료 내역이 없습니다.\n새로운 체험을 예약해보세요!',
-    declined: '아직 취소된 내역이 없어요.',
-    confirmed: '아직 승인된 내역이 없어요.',
-    canceled: '아직 거절된 내역이 없어요.',
-    completed: '아직 완료된 내역이 없어요.',
-  };
 
   return (
     <div className="flex flex-col gap-7.5 pb-17.5">

--- a/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
+++ b/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { useMyReservations } from '@/features/reservation/reservation-list/queries/useMyReservations';
+import type { MyReservationStatus } from '@/features/reservation/types';
+import PageHeader from '@/shared/ui/page-header/PageHeader';
+import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
+import StatusFilter from '../status-filter/StatusFilter';
+import ReservationListSection from './ReservationListSection';
+
+export default function ReservationListView() {
+  const router = useRouter();
+  const [selectedStatus, setSelectedStatus] = useState<ReservationStatus | ''>('pending');
+
+  const { data, isLoading } = useMyReservations({
+    status: (selectedStatus || undefined) as MyReservationStatus | undefined,
+    size: 10,
+  });
+
+  const reservations = useMemo(() => {
+    return data?.reservations ?? [];
+  }, [data?.reservations]);
+
+  const EMPTY_MAIN_TEXT_BY_STATUS: Record<ReservationStatus | '', string> = {
+    '': '아직 예약한 체험이 없어요.\n새로운 체험을 예약해보세요!',
+    pending: '예약 완료 내역이 없습니다.\n새로운 체험을 예약해보세요!',
+    declined: '아직 취소된 내역이 없어요.',
+    confirmed: '아직 승인된 내역이 없어요.',
+    canceled: '아직 거절된 내역이 없어요.',
+    completed: '아직 완료된 내역이 없어요.',
+  };
+
+  return (
+    <div className="flex flex-col gap-7.5 pb-17.5">
+      <div className="flex flex-col gap-3.5">
+        <PageHeader
+          title="예약내역"
+          description="예약내역 변경 및 취소할 수 있습니다."
+          onBack={() => router.back()}
+        />
+        <StatusFilter selectedStatus={selectedStatus} onSelectStatus={setSelectedStatus} />
+      </div>
+
+      <ReservationListSection
+        isLoading={isLoading}
+        reservations={reservations}
+        selectedStatus={selectedStatus}
+        emptyMainTextByStatus={EMPTY_MAIN_TEXT_BY_STATUS}
+      />
+    </div>
+  );
+}

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.stories.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
-import ReservationCard, {
-  ReservationCardData,
-} from '@/features/reservation/reservation-list/ui/reservation-card/ReservationCard';
+import ReservationCard from '@/features/reservation/reservation-list/ui/reservation-card/ReservationCard';
+import type { MyReservation } from '@/features/reservation/types';
 
 const meta: Meta<typeof ReservationCard> = {
   title: 'Features/Card/ReservationCard',
@@ -12,10 +11,9 @@ const meta: Meta<typeof ReservationCard> = {
 export default meta;
 type Story = StoryObj<typeof ReservationCard>;
 
-const mockReservations: ReservationCardData[] = [
+const mockReservations: MyReservation[] = [
   {
     id: 1,
-    nickname: '김민준',
     userId: 101,
     activity: {
       bannerImageUrl: 'https://picsum.photos/seed/activity1/400/300',
@@ -23,7 +21,6 @@ const mockReservations: ReservationCardData[] = [
       id: 201,
     },
     teamId: 'team-alpha',
-    activityId: 201,
     scheduleId: 301,
     status: 'confirmed',
     reviewSubmitted: false,
@@ -32,10 +29,11 @@ const mockReservations: ReservationCardData[] = [
     date: '2026-05-10',
     startTime: '10:00',
     endTime: '12:00',
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
   },
   {
     id: 2,
-    nickname: '이수경',
     userId: 102,
     activity: {
       bannerImageUrl: 'https://picsum.photos/seed/activity2/400/300',
@@ -43,7 +41,6 @@ const mockReservations: ReservationCardData[] = [
       id: 202,
     },
     teamId: 'team-beta',
-    activityId: 202,
     scheduleId: 302,
     status: 'pending',
     reviewSubmitted: false,
@@ -52,10 +49,11 @@ const mockReservations: ReservationCardData[] = [
     date: '2026-05-15',
     startTime: '18:00',
     endTime: '21:00',
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
   },
   {
     id: 3,
-    nickname: '박지훈',
     userId: 103,
     activity: {
       bannerImageUrl: 'https://picsum.photos/seed/activity3/400/300',
@@ -63,7 +61,6 @@ const mockReservations: ReservationCardData[] = [
       id: 203,
     },
     teamId: 'team-gamma',
-    activityId: 203,
     scheduleId: 303,
     status: 'completed',
     reviewSubmitted: true,
@@ -72,10 +69,11 @@ const mockReservations: ReservationCardData[] = [
     date: '2026-04-20',
     startTime: '09:00',
     endTime: '11:00',
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
   },
   {
     id: 6,
-    nickname: '박지훈',
     userId: 103,
     activity: {
       bannerImageUrl: 'https://picsum.photos/seed/activity3/400/300',
@@ -83,7 +81,6 @@ const mockReservations: ReservationCardData[] = [
       id: 203,
     },
     teamId: 'team-gamma',
-    activityId: 203,
     scheduleId: 303,
     status: 'completed',
     reviewSubmitted: false,
@@ -92,10 +89,11 @@ const mockReservations: ReservationCardData[] = [
     date: '2026-04-20',
     startTime: '09:00',
     endTime: '11:00',
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
   },
   {
     id: 4,
-    nickname: '최유나',
     userId: 104,
     activity: {
       bannerImageUrl: 'https://picsum.photos/seed/activity4/400/300',
@@ -103,7 +101,6 @@ const mockReservations: ReservationCardData[] = [
       id: 204,
     },
     teamId: 'team-delta',
-    activityId: 204,
     scheduleId: 304,
     status: 'declined',
     reviewSubmitted: false,
@@ -112,10 +109,11 @@ const mockReservations: ReservationCardData[] = [
     date: '2026-05-01',
     startTime: '14:00',
     endTime: '16:00',
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
   },
   {
     id: 5,
-    nickname: '정도현',
     userId: 105,
     activity: {
       bannerImageUrl: 'https://picsum.photos/seed/activity5/400/300',
@@ -123,7 +121,6 @@ const mockReservations: ReservationCardData[] = [
       id: 205,
     },
     teamId: 'team-epsilon',
-    activityId: 205,
     scheduleId: 305,
     status: 'canceled',
     reviewSubmitted: false,
@@ -132,6 +129,8 @@ const mockReservations: ReservationCardData[] = [
     date: '2026-06-01',
     startTime: '07:00',
     endTime: '13:00',
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
   },
 ];
 // 예약 내역 카드

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.tsx
@@ -1,32 +1,11 @@
+import type { MyReservation } from '@/features/reservation/types';
 import BaseCardImage from '@/shared/ui/card/base/BaseCardImage';
 import { cardImageStyles, cardWrapStyles } from '@/shared/ui/card/cardStyles';
-import { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 import { cn } from '@/shared/utils/cn';
 import ReservationCardInfo from './ReservationCardInfo';
 
-export type ReservationCardData = {
-  id: number;
-  nickname: string;
-  userId: number;
-  activity: {
-    bannerImageUrl: string;
-    title: string;
-    id: number;
-  };
-  teamId: string;
-  activityId: number;
-  scheduleId: number;
-  status: ReservationStatus;
-  reviewSubmitted: boolean;
-  totalPrice: number;
-  headCount: number;
-  date: string;
-  startTime: string;
-  endTime: string;
-};
-
 export type ReservationCardProps = {
-  data: ReservationCardData;
+  data: MyReservation;
 };
 
 /**
@@ -44,7 +23,11 @@ export default function ReservationCard({ data }: ReservationCardProps) {
   return (
     <div className={cn('flex items-center rounded-3xl', cardWrapStyles)}>
       {/* 이미지 */}
-      <BaseCardImage containerClassName={cardImageStyles} alt={data.activity.title} />
+      <BaseCardImage
+        containerClassName={cardImageStyles}
+        bannerImageUrl={data.activity.bannerImageUrl}
+        alt={data.activity.title}
+      />
       {/* 정보 영역 */}
       <div className="relative layer-base w-full">
         <ReservationCardInfo data={data} />

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
@@ -19,17 +19,8 @@ import type { ReservationCardProps } from './ReservationCard';
  * ```
  */
 export default function ReservationCardInfo({ data }: ReservationCardProps) {
-  const {
-    activity,
-    totalPrice,
-    headCount,
-    status,
-    date,
-    startTime,
-    endTime,
-    reviewSubmitted,
-    activityId,
-  } = data;
+  const { activity, totalPrice, headCount, status, date, startTime, endTime, reviewSubmitted } =
+    data;
   const { title } = activity;
 
   return (
@@ -64,7 +55,7 @@ export default function ReservationCardInfo({ data }: ReservationCardProps) {
           type="reservation"
           status={status}
           reviewSubmitted={reviewSubmitted}
-          activityId={activityId}
+          activityId={activity.id}
         />
       </div>
     </BaseCardInfo>

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
@@ -5,6 +5,7 @@ import TotalPrice from '@/shared/ui/price/TotalPrice';
 import StateBadge from '@/shared/ui/state-badge/StateBadge';
 import Title from '@/shared/ui/title/Title';
 import { cn } from '@/shared/utils/cn';
+import { formatYmdToDot } from '@/shared/utils/dateFormat';
 import type { ReservationCardProps } from './ReservationCard';
 
 /**
@@ -37,7 +38,7 @@ export default function ReservationCardInfo({ data }: ReservationCardProps) {
 
         {/* 예약 날짜 + 시간 */}
         <p className="flex gap-1 typo-13-medium text-gray-500 lg:typo-16-medium">
-          <span className="hidden lg:inline-block">{date}</span>
+          <span className="hidden lg:inline-block">{formatYmdToDot(date)}</span>
           <span className="hidden lg:inline-block">·</span>
           <span>
             {startTime} - {endTime}

--- a/src/features/reservation/reservation-list/ui/status-filter/StatusFilter.stories.tsx
+++ b/src/features/reservation/reservation-list/ui/status-filter/StatusFilter.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 import { useState } from 'react';
 import StatusFilter from '@/features/reservation/reservation-list/ui/status-filter/StatusFilter';
+import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 
 const meta: Meta<typeof StatusFilter> = {
   title: 'Features/Reservation/StatusFilter',
@@ -14,7 +15,7 @@ type Story = StoryObj<typeof StatusFilter>;
 export const Default: Story = {
   render: () => {
     function StoryWrapper() {
-      const [status, setStatus] = useState('');
+      const [status, setStatus] = useState<ReservationStatus | ''>('');
       return (
         <div className="w-fit rounded-xl bg-gray-50 p-8">
           <StatusFilter selectedStatus={status} onSelectStatus={setStatus} />

--- a/src/features/reservation/reservation-list/ui/status-filter/StatusFilter.tsx
+++ b/src/features/reservation/reservation-list/ui/status-filter/StatusFilter.tsx
@@ -1,10 +1,17 @@
 import FilterButton from '@/shared/ui/filter-button/FilterButton';
+import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 
-const STATUS_LIST = ['예약 완료', '예약 취소', '예약 승인', '예약 거절', '체험 완료'];
+const STATUS_LIST: Array<{ id: ReservationStatus; label: string }> = [
+  { id: 'confirmed', label: '예약 완료' },
+  { id: 'canceled', label: '예약 취소' },
+  { id: 'pending', label: '예약 승인' },
+  { id: 'declined', label: '예약 거절' },
+  { id: 'completed', label: '체험 완료' },
+];
 
 type StatusFilterProps = {
-  selectedStatus: string;
-  onSelectStatus: (status: string) => void;
+  selectedStatus: ReservationStatus | '';
+  onSelectStatus: (status: ReservationStatus | '') => void;
 };
 
 /**
@@ -27,17 +34,18 @@ type StatusFilterProps = {
  */
 export default function StatusFilter({ selectedStatus, onSelectStatus }: StatusFilterProps) {
   return (
-    <div className="flex flex-wrap gap-2">
-      {STATUS_LIST.map((status) => (
+    <div className="scrollbar-hide flex flex-nowrap gap-2 overflow-x-auto overflow-y-hidden md:flex-wrap md:overflow-x-visible">
+      {STATUS_LIST.map(({ id, label }) => (
         <FilterButton
-          key={status}
-          isSelected={selectedStatus === status}
+          key={id}
+          isSelected={selectedStatus === id}
+          className="shrink-0"
           onClick={() => {
             // 이미 선택된 것을 누르면 선택 해제, 아니면 해당 상태로 변경
-            onSelectStatus(selectedStatus === status ? '' : status);
+            onSelectStatus(selectedStatus === id ? '' : id);
           }}
         >
-          {status}
+          {label}
         </FilterButton>
       ))}
     </div>

--- a/src/features/reservation/reservation-list/ui/status-filter/StatusFilter.tsx
+++ b/src/features/reservation/reservation-list/ui/status-filter/StatusFilter.tsx
@@ -2,10 +2,10 @@ import FilterButton from '@/shared/ui/filter-button/FilterButton';
 import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 
 const STATUS_LIST: Array<{ id: ReservationStatus; label: string }> = [
-  { id: 'confirmed', label: '예약 완료' },
-  { id: 'canceled', label: '예약 취소' },
-  { id: 'pending', label: '예약 승인' },
-  { id: 'declined', label: '예약 거절' },
+  { id: 'pending', label: '예약 완료' },
+  { id: 'declined', label: '예약 취소' },
+  { id: 'confirmed', label: '예약 승인' },
+  { id: 'canceled', label: '예약 거절' },
   { id: 'completed', label: '체험 완료' },
 ];
 

--- a/src/features/reservation/reservation-list/ui/status-filter/StatusFilter.tsx
+++ b/src/features/reservation/reservation-list/ui/status-filter/StatusFilter.tsx
@@ -3,9 +3,9 @@ import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 
 const STATUS_LIST: Array<{ id: ReservationStatus; label: string }> = [
   { id: 'pending', label: '예약 완료' },
-  { id: 'declined', label: '예약 취소' },
+  { id: 'declined', label: '예약 거절' },
   { id: 'confirmed', label: '예약 승인' },
-  { id: 'canceled', label: '예약 거절' },
+  { id: 'canceled', label: '예약 취소' },
   { id: 'completed', label: '체험 완료' },
 ];
 

--- a/src/features/reservation/types.ts
+++ b/src/features/reservation/types.ts
@@ -1,4 +1,14 @@
-export type MyReservationStatus = 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed';
+import { z } from 'zod';
+
+export const MyReservationStatusSchema = z.enum([
+  'pending',
+  'confirmed',
+  'declined',
+  'canceled',
+  'completed',
+]);
+
+export type MyReservationStatus = z.infer<typeof MyReservationStatusSchema>;
 
 export type GetMyReservationsQuery = {
   cursorId?: number;
@@ -6,34 +16,40 @@ export type GetMyReservationsQuery = {
   status?: MyReservationStatus;
 };
 
-export type MyReservationActivitySummary = {
-  bannerImageUrl: string;
-  title: string;
-  id: number;
-};
+export const MyReservationActivitySummarySchema = z.object({
+  bannerImageUrl: z.string(),
+  title: z.string(),
+  id: z.number(),
+});
 
-export type MyReservation = {
-  id: number;
-  teamId: string;
-  userId: number;
-  activity: MyReservationActivitySummary;
-  scheduleId: number;
-  status: MyReservationStatus;
-  reviewSubmitted: boolean;
-  totalPrice: number;
-  headCount: number;
-  date: string;
-  startTime: string;
-  endTime: string;
-  createdAt: string;
-  updatedAt: string;
-};
+export type MyReservationActivitySummary = z.infer<typeof MyReservationActivitySummarySchema>;
 
-export type GetMyReservationsResponse = {
-  cursorId: number;
-  reservations: MyReservation[];
-  totalCount: number;
-};
+export const MyReservationSchema = z.object({
+  id: z.number(),
+  teamId: z.string(),
+  userId: z.number(),
+  activity: MyReservationActivitySummarySchema,
+  scheduleId: z.number(),
+  status: MyReservationStatusSchema,
+  reviewSubmitted: z.boolean(),
+  totalPrice: z.number(),
+  headCount: z.number(),
+  date: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type MyReservation = z.infer<typeof MyReservationSchema>;
+
+export const GetMyReservationsResponseSchema = z.object({
+  cursorId: z.number().nullable(),
+  reservations: z.array(MyReservationSchema),
+  totalCount: z.number(),
+});
+
+export type GetMyReservationsResponse = z.infer<typeof GetMyReservationsResponseSchema>;
 
 export type CancelMyReservationRequestBody = {
   status: 'canceled';

--- a/src/shared/constants/queryKey.ts
+++ b/src/shared/constants/queryKey.ts
@@ -3,6 +3,12 @@
  * query key는 문자열을 직접 작성하지 않고 이 상수를 통해 참조합니다.
  */
 export const QUERY_KEYS = {
+  /** 체험 상세 조회 */
   ACTIVITY_DETAIL: (id: number) => ['activity', id] as const,
+  /** 메인 - 인기 체험 조회 */
   HOT_ACTIVITY: (size: number) => ['activities', 'hot', size] as const,
+
+  /** 내 예약 내역 조회 */
+  MY_RESERVATIONS: (status?: string, size?: number) =>
+    ['my-reservations', status ?? 'all', size ?? 'default'] as const,
 } as const;

--- a/src/shared/ui/card/CardActions.tsx
+++ b/src/shared/ui/card/CardActions.tsx
@@ -22,7 +22,7 @@ type CardActionsProps = ManageCardActionsProps | ReservationCardActionsProps;
  * type에 따라 내 체험 관리(manage)와 예약 내역(reservation) 두 가지 버전으로 렌더링됩니다.
  * - manage: 수정하기 / 삭제하기 버튼
  * - reservation: 예약 상태(status)에 따라 버튼이 다르게 노출됩니다.
- *   - confirmed: 예약 변경 / 예약 취소 버튼
+ *   - pending: 예약 변경 / 예약 취소 버튼
  *   - completed: 후기 작성하기 / 후기 작성 완료(비활성) 버튼
  *
  * @example
@@ -31,7 +31,7 @@ type CardActionsProps = ManageCardActionsProps | ReservationCardActionsProps;
  * <CardActions type="manage" activityId={1} />
  *
  * // 예약 완료 카드
- * <CardActions type="reservation" status="confirmed" activityId={1} />
+ * <CardActions type="reservation" status="pending" activityId={1} />
  *
  * // 체험 완료 카드 - 후기 미작성
  * <CardActions type="reservation" status="completed" reviewSubmitted={false} />
@@ -71,7 +71,7 @@ export default function CardActions(props: CardActionsProps) {
   const { status, reviewSubmitted, activityId } = props;
 
   // 예약 완료 시 버튼
-  if (status === 'confirmed') {
+  if (status === 'pending') {
     return (
       <div className="flex gap-2">
         <Button

--- a/src/shared/ui/state-badge/StateBadge.tsx
+++ b/src/shared/ui/state-badge/StateBadge.tsx
@@ -24,12 +24,12 @@ const RESERVATION_BADGE_MAP: Record<ReservationStatus, { label: string; classNam
     className: 'bg-blue-100 text-blue-400',
   },
   declined: {
-    label: '예약 취소',
-    className: 'bg-gray-100 text-gray-600',
-  },
-  canceled: {
     label: '예약 거절',
     className: 'bg-red-100 text-red-400',
+  },
+  canceled: {
+    label: '예약 취소',
+    className: 'bg-gray-100 text-gray-600',
   },
 };
 

--- a/src/shared/ui/state-badge/StateBadge.tsx
+++ b/src/shared/ui/state-badge/StateBadge.tsx
@@ -10,7 +10,7 @@ export type StateBadgeProps = {
 /**
  * 예약 상태별 뱃지 스타일 및 라벨 맵
  */
-const ReservationBadgeMap: Record<ReservationStatus, { label: string; className: string }> = {
+const RESERVATION_BADGE_MAP: Record<ReservationStatus, { label: string; className: string }> = {
   pending: {
     label: '예약 완료',
     className: 'bg-green-100 text-green-400',
@@ -50,7 +50,7 @@ const ReservationBadgeMap: Record<ReservationStatus, { label: string; className:
  * ```
  */
 export default function StateBadge({ status, className }: StateBadgeProps) {
-  const { label, className: badgeClassName } = ReservationBadgeMap[status];
+  const { label, className: badgeClassName } = RESERVATION_BADGE_MAP[status];
 
   return (
     <span

--- a/src/shared/ui/state-badge/StateBadge.tsx
+++ b/src/shared/ui/state-badge/StateBadge.tsx
@@ -10,26 +10,26 @@ export type StateBadgeProps = {
 /**
  * 예약 상태별 뱃지 스타일 및 라벨 맵
  */
-const RESERVATION_BADGE_MAP: Record<ReservationStatus, { label: string; className: string }> = {
+const ReservationBadgeMap: Record<ReservationStatus, { label: string; className: string }> = {
   pending: {
-    label: '예약 승인',
-    className: 'bg-mint-100 text-mint-400',
-  },
-  confirmed: {
     label: '예약 완료',
     className: 'bg-green-100 text-green-400',
+  },
+  confirmed: {
+    label: '예약 승인',
+    className: 'bg-mint-100 text-mint-400',
   },
   completed: {
     label: '체험 완료',
     className: 'bg-blue-100 text-blue-400',
   },
   declined: {
-    label: '예약 거절',
-    className: 'bg-red-100 text-red-400',
-  },
-  canceled: {
     label: '예약 취소',
     className: 'bg-gray-100 text-gray-600',
+  },
+  canceled: {
+    label: '예약 거절',
+    className: 'bg-red-100 text-red-400',
   },
 };
 
@@ -50,7 +50,7 @@ const RESERVATION_BADGE_MAP: Record<ReservationStatus, { label: string; classNam
  * ```
  */
 export default function StateBadge({ status, className }: StateBadgeProps) {
-  const { label, className: badgeClassName } = RESERVATION_BADGE_MAP[status];
+  const { label, className: badgeClassName } = ReservationBadgeMap[status];
 
   return (
     <span

--- a/src/shared/utils/dateFormat.ts
+++ b/src/shared/utils/dateFormat.ts
@@ -1,0 +1,13 @@
+/**
+ * `YYYY-MM-DD` 형식의 날짜 문자열을 `YYYY. MM. DD`로 포맷합니다.
+ *
+ * - 입력이 예상 형식이 아니면 원본 문자열을 그대로 반환합니다.
+ *
+ * @example
+ * formatYmdToDot('2026-05-09') // '2026. 05. 09'
+ */
+export const formatYmdToDot = (value: string): string => {
+  const [year, month, day] = value.split('-');
+  if (!year || !month || !day) return value;
+  return `${year}. ${month.padStart(2, '0')}. ${day.padStart(2, '0')}`;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #152 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

마이페이지 예약내역 페이지 퍼블리싱과 Get API 연결까지만 진행했습니다!

### 예약내역 페이지 구성
- 필터 별 Empty State 추가
- 날짜별 그룹핑 + 섹션 구분선 적용


### 내 예약내역 조회(API + Query)
- /api/my-reservations 호출 함수 추가 및 Zod 파싱 적용
- QUERY_KEYS.MY_RESERVATIONS 추가 및 키 주석 정리
- 내 예약내역 응답/아이템 Zod 스키마 및 z.infer 기반 타입 정의

### 필터/카드 표시 개선
- 필터의 경우, 모바일 가로 스크롤 가능하도록 수정
- Reservation Card가 MyReservation 타입을 직접 받도록 변경(변환 함수를 쓰지 않기 위해)
- 예약 상태 라벨/색상 매핑 조정
  - pending이 예약 승인으로 맵핑이 되어있어서 예약 완료가 pending으로 될 수 있게 수정했습니다


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

### 이후로 작업해야할 것
- 삭제 API 연결 및 삭제 모달 추가
- 무한 스크롤
- mutation 적용
- 후기 작성 모달 연결 및 API 연결 
- 예약 변경 페이지로 router 처리 필요