### PR TITLE
[✨ Feat/173] 내 정보에서 로그인 방식(auth/oauth) 분기 지원

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { AUTH_API_MESSAGE } from '@/features/auth/constants/authMessage';
 import { LoginResponse } from '@/features/auth/types/auth';
-import { setAuthCookies } from '@/features/auth/utils/cookies';
+import { setAuthCookies, setLoginMethodCookie } from '@/features/auth/utils/cookies';
 import { getJwtExpiresAt } from '@/features/auth/utils/jwt';
 import { LoginFormValues } from '@/features/auth/utils/schema';
 import { ApiError } from '@/shared/apis/apiError';
@@ -43,9 +43,11 @@ export async function POST(request: Request) {
       success: true,
       user: data.user,
       accessTokenExpiresAt,
+      loginMethod: 'auth' as const,
     });
 
     setAuthCookies({ response, accessToken: data.accessToken, refreshToken: data.refreshToken });
+    setLoginMethodCookie({ response, loginMethod: 'auth' });
 
     return response;
   } catch (error) {

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { AUTH_API_MESSAGE } from '@/features/auth/constants/authMessage';
-import { clearAuthCookies } from '@/features/auth/utils/cookies';
+import { clearAuthCookies, clearLoginMethodCookie } from '@/features/auth/utils/cookies';
 
 /**
  * POST /api/auth/logout
@@ -14,6 +14,7 @@ export async function POST() {
   try {
     const response = NextResponse.json({ success: true });
     clearAuthCookies(response);
+    clearLoginMethodCookie(response);
 
     return response;
   } catch {

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,3 +1,5 @@
+import { cookies } from 'next/headers';
+import { LOGIN_METHOD_COOKIE_KEY, type LoginMethod } from '@/features/auth/constants/loginMethod';
 import type { UpdateMyProfileRequestBody, UserResponse } from '@/features/user/types';
 import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
 import { proxyFetch } from '@/shared/apis/bff/proxy';
@@ -17,7 +19,14 @@ import { proxyFetch } from '@/shared/apis/bff/proxy';
  * @returns 사용자 정보 (`UserResponse`)
  */
 export const GET = createAuthorizedRoute(async () => {
-  return proxyFetch.get<UserResponse>('/users/me');
+  const me = await proxyFetch.get<UserResponse>('/users/me');
+  if (!me) return me;
+
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(LOGIN_METHOD_COOKIE_KEY)?.value;
+  const loginMethod: LoginMethod | null = raw === 'auth' || raw === 'oauth' ? raw : null;
+
+  return { ...me, loginMethod };
 });
 
 /**

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,6 +1,10 @@
 import { cookies } from 'next/headers';
 import { LOGIN_METHOD_COOKIE_KEY, type LoginMethod } from '@/features/auth/constants/loginMethod';
-import type { UpdateMyProfileRequestBody, UserResponse } from '@/features/user/types';
+import type {
+  UpdateMyProfileRequestBody,
+  UserMeResponse,
+  UserResponse,
+} from '@/features/user/types';
 import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
 import { proxyFetch } from '@/shared/apis/bff/proxy';
 
@@ -16,7 +20,7 @@ import { proxyFetch } from '@/shared/apis/bff/proxy';
  * - 실제 데이터 조회는 `proxyFetch`가 백엔드 API(`/users/me`)로 요청을 전달하며,
  *   쿠키의 `accessToken`을 `Authorization: Bearer ...` 헤더로 주입합니다.
  *
- * @returns 사용자 정보 (`UserResponse`)
+ * @returns 사용자 정보 (`UserMeResponse`)
  */
 export const GET = createAuthorizedRoute(async () => {
   const me = await proxyFetch.get<UserResponse>('/users/me');
@@ -26,7 +30,7 @@ export const GET = createAuthorizedRoute(async () => {
   const raw = cookieStore.get(LOGIN_METHOD_COOKIE_KEY)?.value;
   const loginMethod: LoginMethod | null = raw === 'auth' || raw === 'oauth' ? raw : null;
 
-  return { ...me, loginMethod };
+  return { ...me, loginMethod } satisfies UserMeResponse;
 });
 
 /**

--- a/src/features/auth/constants/loginMethod.ts
+++ b/src/features/auth/constants/loginMethod.ts
@@ -1,0 +1,3 @@
+export type LoginMethod = 'auth' | 'oauth';
+
+export const LOGIN_METHOD_COOKIE_KEY = 'loginMethod';

--- a/src/features/auth/types/oauth.ts
+++ b/src/features/auth/types/oauth.ts
@@ -1,3 +1,4 @@
+import type { LoginMethod } from '@/features/auth/constants/loginMethod';
 import type { UserResponse } from '@/features/user/types';
 
 export type OauthProvider = 'kakao';
@@ -20,4 +21,5 @@ export type OauthAuthResponse = {
 export type OauthSessionResponseBody = {
   user: UserResponse;
   accessTokenExpiresAt: number;
+  loginMethod: LoginMethod;
 };

--- a/src/features/auth/utils/cookies.ts
+++ b/src/features/auth/utils/cookies.ts
@@ -25,6 +25,11 @@ interface SetAuthCookiesOptions {
   refreshToken: string;
 }
 
+interface SetLoginMethodCookieParams {
+  response: NextResponse;
+  loginMethod: LoginMethod;
+}
+
 /**
  * ## setAuthCookies
  *
@@ -64,14 +69,31 @@ export const clearAuthCookies = (response: NextResponse): void => {
   response.cookies.set('refreshToken', '', { ...COOKIE_OPTIONS, maxAge: 0 });
 };
 
-export const setLoginMethodCookie = (params: {
-  response: NextResponse;
-  loginMethod: LoginMethod;
-}): void => {
+/**
+ * ## setLoginMethodCookie
+ *
+ * @description
+ * 로그인 방식을 구분하기 위한 쿠키를 설정하는 유틸 함수입니다.
+ *
+ * @param params - response 객체와 로그인 방식(auth/oauth)
+ * @example
+ * setLoginMethodCookie({ response, loginMethod: 'auth' });
+ */
+export const setLoginMethodCookie = (params: SetLoginMethodCookieParams): void => {
   const { response, loginMethod } = params;
   response.cookies.set(LOGIN_METHOD_COOKIE_KEY, loginMethod, COOKIE_OPTIONS);
 };
 
+/**
+ * ## clearLoginMethodCookie
+ *
+ * @description
+ * 로그인 방식 쿠키를 만료시키는 유틸 함수입니다.
+ *
+ * @param response - 쿠키를 만료시킬 `NextResponse` 객체
+ * @example
+ * clearLoginMethodCookie(response);
+ */
 export const clearLoginMethodCookie = (response: NextResponse): void => {
   response.cookies.set(LOGIN_METHOD_COOKIE_KEY, '', { ...COOKIE_OPTIONS, maxAge: 0 });
 };

--- a/src/features/auth/utils/cookies.ts
+++ b/src/features/auth/utils/cookies.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { COOKIE_OPTIONS } from '@/features/auth/constants/cookies';
+import { LOGIN_METHOD_COOKIE_KEY, type LoginMethod } from '@/features/auth/constants/loginMethod';
 import { getJwtMaxAge } from '@/features/auth/utils/jwt';
 
 export type AuthToken = 'accessToken' | 'refreshToken';
@@ -61,4 +62,16 @@ export const setAuthCookies = ({
 export const clearAuthCookies = (response: NextResponse): void => {
   response.cookies.set('accessToken', '', { ...COOKIE_OPTIONS, maxAge: 0 });
   response.cookies.set('refreshToken', '', { ...COOKIE_OPTIONS, maxAge: 0 });
+};
+
+export const setLoginMethodCookie = (params: {
+  response: NextResponse;
+  loginMethod: LoginMethod;
+}): void => {
+  const { response, loginMethod } = params;
+  response.cookies.set(LOGIN_METHOD_COOKIE_KEY, loginMethod, COOKIE_OPTIONS);
+};
+
+export const clearLoginMethodCookie = (response: NextResponse): void => {
+  response.cookies.set(LOGIN_METHOD_COOKIE_KEY, '', { ...COOKIE_OPTIONS, maxAge: 0 });
 };

--- a/src/features/auth/utils/oauthSessionServer.ts
+++ b/src/features/auth/utils/oauthSessionServer.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { OauthSessionResponseBody } from '@/features/auth/types/oauth';
-import { setAuthCookies } from '@/features/auth/utils/cookies';
+import { setAuthCookies, setLoginMethodCookie } from '@/features/auth/utils/cookies';
 import { getJwtExpiresAt } from '@/features/auth/utils/jwt';
 import type { UserResponse } from '@/features/user/types';
 import { ENV } from '@/shared/apis/env';
@@ -20,9 +20,10 @@ export const createOAuthSessionResponse = (params: {
 
   const accessTokenExpiresAt = getJwtExpiresAt(accessToken);
 
-  const response = NextResponse.json({ user, accessTokenExpiresAt });
+  const response = NextResponse.json({ user, accessTokenExpiresAt, loginMethod: 'oauth' as const });
 
   setAuthCookies({ response, accessToken, refreshToken });
+  setLoginMethodCookie({ response, loginMethod: 'oauth' });
 
   return response;
 };

--- a/src/features/user/apis.ts
+++ b/src/features/user/apis.ts
@@ -1,6 +1,6 @@
-import type { UserResponse } from '@/features/user/types';
+import type { UserMeResponse } from '@/features/user/types';
 import { bffFetch } from '@/shared/apis/base/bffFetch';
 
 export const getMe = async () => {
-  return bffFetch.get<UserResponse>('/users/me');
+  return bffFetch.get<UserMeResponse>('/users/me');
 };

--- a/src/features/user/types.ts
+++ b/src/features/user/types.ts
@@ -7,6 +7,17 @@ export type UserResponse = {
   updatedAt: string;
 };
 
+/**
+ * ## UserMeResponse
+ *
+ * @description
+ * BFF `GET /users/me` 응답 타입입니다.
+ * 기본 사용자 정보(`UserResponse`)에 로그인 방식(`loginMethod`)을 추가로 포함합니다.
+ */
+export type UserMeResponse = UserResponse & {
+  loginMethod: 'auth' | 'oauth' | null;
+};
+
 export type UpdateMyProfileRequestBody = {
   nickname?: string;
   profileImageUrl?: string;

--- a/src/shared/stores/userStore.ts
+++ b/src/shared/stores/userStore.ts
@@ -69,7 +69,10 @@ export const useUserStore = create<
     ['zustand/devtools', never],
     [
       'zustand/persist',
-      { user: UserResponse | undefined; accessTokenExpiresAt: number | undefined },
+      {
+        user: UserResponse | undefined;
+        accessTokenExpiresAt: number | undefined;
+      },
     ],
   ]
 >(
@@ -92,7 +95,11 @@ export const useUserStore = create<
           ),
         clearSession: (reason) =>
           set(
-            { user: undefined, accessTokenExpiresAt: undefined, sessionEndReason: reason },
+            {
+              user: undefined,
+              accessTokenExpiresAt: undefined,
+              sessionEndReason: reason,
+            },
             false,
             'user/clearSession'
           ),


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #173

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 구현
- 마이페이지 “내 정보”에서 로그인 방식에 따라(이메일/비밀번호 로그인 vs OAuth 로그인) 비밀번호 변경 UI를 분기할 수 있도록, BFF GET /api/users/me 응답에 loginMethod를 포함했습니다
- 내 정보 페이지는 /users/me 응답의 loginMethod만 사용해 분기합니다(별도 엔드포인트 없음).

### 사용 예시
구현을 한건 아니라서 구조는 살짝 다를 수도 있습니당

```
import type { LoginMethod } from '@/features/auth/constants/loginMethod';
import { bffFetch } from '@/shared/apis/base/bffFetch';

type MeResponse = {
  id: number;
  email: string;
  nickname: string;
  profileImageUrl: string | null;
  createdAt: string;
  updatedAt: string;
  loginMethod: LoginMethod | null;
};

export default function MyInfoPage() {

  return (
...
      {me.loginMethod === 'auth' ? (
        <section>비밀번호 변경 UI</section>
      ) : me.loginMethod === 'oauth' ? (
        <section>소셜 로그인은 비밀번호 변경 불가 안내</section>
      ) : (
        <section>로그인 방식 확인 불가(재시도 안내)</section>
      )}
.....
  );
}
```


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
