### PR TITLE
[🚨Fix/#176] 검색페이지 무한 렌더링 버그 해결

### DIFF
--- a/src/features/activity/main/ui/category-filter/CategoryFilter.tsx
+++ b/src/features/activity/main/ui/category-filter/CategoryFilter.tsx
@@ -29,12 +29,13 @@ export default function CategoryFilter({
   onChangeCategory,
 }: CategoryFilterProps) {
   return (
-    <div className="flex flex-wrap gap-4">
+    <div className="scrollbar-hide flex flex-nowrap gap-2 overflow-x-auto overflow-y-hidden md:flex-wrap md:overflow-x-visible">
       {CATEGORY_LIST.map((category) => (
         <FilterButton
           key={category}
           isSelected={selectedCategory === category}
           onClick={() => onChangeCategory(category)}
+          className="shrink-0"
         >
           {category}
         </FilterButton>

--- a/src/features/activity/search/hooks/useSearchResult.ts
+++ b/src/features/activity/search/hooks/useSearchResult.ts
@@ -60,10 +60,15 @@ export const useSearchResult = () => {
 
   // pageSize 변경 시 페이지 초기화
   useEffect(() => {
+    if (!pageSize) return;
+
+    const params = new URLSearchParams(window.location.search);
+    params.set('page', '1');
+
     startTransition(() => {
-      updateParams({ page: '1' }, 'replace');
+      router.replace('/search?' + params.toString());
     });
-  }, [pageSize, updateParams]);
+  }, [pageSize, router]);
 
   // 검색 카테고리
   const { data } = useSearchActivityData({

--- a/src/features/activity/search/hooks/useSearchResult.ts
+++ b/src/features/activity/search/hooks/useSearchResult.ts
@@ -41,7 +41,7 @@ export const useSearchResult = () => {
   // push: 히스토리에 추가 (뒤로가기 가능), replace: 현재 URL 덮어쓰기
   const updateParams = useCallback(
     (updates: Record<string, string>, mode: 'push' | 'replace' = 'push') => {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(window.location.search);
       Object.entries(updates).forEach(([key, value]) => params.set(key, value));
 
       if (mode === 'replace') {
@@ -50,7 +50,7 @@ export const useSearchResult = () => {
         router.push('/search?' + params.toString());
       }
     },
-    [searchParams, router]
+    [router]
   );
 
   // 카테고리 변경 시 page 1로 초기화
@@ -61,14 +61,10 @@ export const useSearchResult = () => {
   // pageSize 변경 시 페이지 초기화
   useEffect(() => {
     if (!pageSize) return;
-
-    const params = new URLSearchParams(window.location.search);
-    params.set('page', '1');
-
     startTransition(() => {
-      router.replace('/search?' + params.toString());
+      updateParams({ page: '1' }, 'replace');
     });
-  }, [pageSize, router]);
+  }, [pageSize, updateParams]);
 
   // 검색 카테고리
   const { data } = useSearchActivityData({


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #176

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 문제
pageSize 변경 시 첫 번째 페이지로 이동시키는 useEffect의 의존성 배열에 작성한
updateParams가 searchParams를 deps로 가지고 있어서 URL이 바뀔 때마다
updateParams가 재생성되어 무한 렌더링 발생

### 해결
updateParams 대신 router 직접 사용하여 searchParams 의존성으로 인한 무한 렌더링 방지

(+ 추가로 카테고리필터 버튼도 StatusFilter처럼 가로 스크롤 가능하게 스타일 변경했습니당)

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
