### PR TITLE
[🐛 Fix/#188] 드롭다운 긴 제목 말줄임 처리

### DIFF
--- a/src/shared/ui/dropdown/select/SelectDropdown.stories.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdown.stories.tsx
@@ -110,6 +110,16 @@ const CATEGORY_OPTIONS = [
   { value: '웰빙', label: '웰빙', disabled: false },
 ];
 
+const LONG_TEXT_OPTIONS = [
+  {
+    value: 'long-1',
+    label:
+      '제목이 아주아주 길어서 드롭다운 트리거/옵션에서 말줄임(...)이 제대로 적용되는지 확인하는 테스트 항목입니다',
+    disabled: false,
+  },
+  { value: 'long-2', label: '짧은 옵션', disabled: false },
+] as const;
+
 export const Default: Story = {
   args: {
     variants: 'basic',
@@ -144,6 +154,54 @@ export const Default: Story = {
 
           <SelectDropdownContent>
             {CATEGORY_OPTIONS.map((opt) => (
+              <SelectDropdownItem key={opt.value} value={opt.value} disabled={opt.disabled}>
+                {opt.label}
+              </SelectDropdownItem>
+            ))}
+          </SelectDropdownContent>
+        </SelectDropdown>
+      </div>
+    );
+  },
+};
+
+export const LongText: Story = {
+  args: {
+    variants: 'basic',
+    value: LONG_TEXT_OPTIONS[0].value,
+    triggerId: 'long-text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '텍스트가 길어도 트리거/옵션에서 UI가 깨지지 않고 말줄임(...) 처리되는지 확인하는 예제입니다.',
+      },
+    },
+  },
+  render: (args) => {
+    const [{ value }, updateArgs] = useArgs<{ value: string }>();
+
+    return (
+      <div className="flex h-80 w-60 flex-col gap-2">
+        <SelectDropdown
+          {...args}
+          value={value}
+          onChangeValue={(nextValue: string) => {
+            updateArgs({ value: nextValue });
+          }}
+        >
+          <SelectDropdownTrigger>
+            <SelectDropdownValue
+              placeholder="옵션 선택"
+              render={(value: string) =>
+                LONG_TEXT_OPTIONS.find((opt) => opt.value === value)?.label
+              }
+            />
+          </SelectDropdownTrigger>
+
+          <SelectDropdownContent>
+            {LONG_TEXT_OPTIONS.map((opt) => (
               <SelectDropdownItem key={opt.value} value={opt.value} disabled={opt.disabled}>
                 {opt.label}
               </SelectDropdownItem>

--- a/src/shared/ui/dropdown/select/SelectDropdownItem.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdownItem.tsx
@@ -73,6 +73,8 @@ export default function SelectDropdownItem<T = string>({
   const { value: selectedValue, setValue, variants } = useSelectContext<T>();
 
   const isSelected = selectedValue === value;
+  // 긴 텍스트는 `truncate`로 말줄임 처리되므로, hover 시 전체 내용을 확인할 수 있도록 title을 제공합니다.
+  const title = typeof children === 'string' ? children : undefined;
 
   const selectOption = () => {
     if (disabled) {
@@ -93,6 +95,7 @@ export default function SelectDropdownItem<T = string>({
       aria-disabled={disabled || undefined}
       tabIndex={disabled ? -1 : 0}
       className={cn(dropdownItemVariants({ variants, disabled, selected: isSelected }))}
+      title={title}
       onClick={selectOption}
       onKeyDown={handleKeyDown}
     >

--- a/src/shared/ui/dropdown/select/SelectDropdownTrigger.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdownTrigger.tsx
@@ -8,7 +8,7 @@ import useDropdownBaseContext from '@/shared/ui/dropdown/hooks/useDropdownBaseCo
 import useSelectContext from '@/shared/ui/dropdown/hooks/useSelectDropdownContext';
 import { cn } from '@/shared/utils/cn';
 
-const selectDropdownTriggerVariants = cva('flex items-center', {
+const selectDropdownTriggerVariants = cva('flex min-w-0 items-center', {
   variants: {
     variants: {
       basic: 'field-surface w-full justify-between rounded-2xl px-4 h-13.5',
@@ -74,7 +74,7 @@ export default function SelectDropdownTrigger({
       )}
       onClick={() => setIsOpen((prev) => !prev)}
     >
-      {children}
+      <span className="min-w-0 flex-1 overflow-hidden text-left">{children}</span>
       <span
         aria-hidden="true"
         className={cn(

--- a/src/shared/ui/dropdown/select/SelectDropdownValue.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdownValue.tsx
@@ -15,7 +15,7 @@ type SelectDropdownValueProps<T = string> = {
   valueClassName?: string;
 };
 
-const dropdownValueStyle = 'typo-16-medium text-gray-900';
+const dropdownValueStyle = 'block min-w-0 truncate typo-16-medium text-gray-900';
 
 /**
  * SelectDropdownValue

--- a/src/shared/ui/dropdown/styles/dropdownItem.ts
+++ b/src/shared/ui/dropdown/styles/dropdownItem.ts
@@ -2,7 +2,7 @@
  * 드롭다운 아이템 스타일 상수들
  */
 
-export const dropdownItemBase = 'cursor-pointer typo-16-medium';
+export const dropdownItemBase = 'cursor-pointer truncate typo-16-medium';
 export const dropdownItemHoverBase = 'hover:bg-primary-50 hover:text-primary-500';
 export const dropdownItemShadowStyle =
   'max-w-30 rounded-md px-3 py-1 typo-16-medium text-gray-900 text-center whitespace-nowrap hover:font-semibold';


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #188

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 문제
<img width="669" height="226" alt="image" src="https://github.com/user-attachments/assets/20320adb-6953-4027-902c-5cd07d78ecee" />
- 예약현황 테스트하다가 제목이 너무 길 경우, ui가 깨지는 문제가 발생한 것을 발견했습니다

### 해결
- 공통 드롭다운에 말줄임으로 구현하고 목록에서 hover시 전체 제목을 확인할 수 있도록 구현했습니다

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
