### PR TITLE
[✨ Feat/#180] 헤더 로그아웃 처리 기능 구현

### DIFF
--- a/src/app/ui/header/HeaderContainer.tsx
+++ b/src/app/ui/header/HeaderContainer.tsx
@@ -1,16 +1,19 @@
 'use client';
 
+import { useLogout } from '@/shared/hooks/useLogout';
 import { useUserStore } from '@/shared/stores/userStore';
 import Header from '@/shared/ui/header/Header';
 
 export default function HeaderContainer() {
   const hasHydrated = useUserStore((state) => state.hasHydrated);
   const user = useUserStore((state) => state.user);
+  const { handleLogout } = useLogout();
 
   return (
     <Header
       isLoggedIn={hasHydrated && !!user}
       user={user ? { nickname: user.nickname, profileImageUrl: user.profileImageUrl } : undefined}
+      onLogout={handleLogout}
     />
   );
 }

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -7,6 +7,11 @@ import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
  * 로그아웃을 처리하는 훅입니다.
  * BFF Route Handler를 호출해 HttpOnly 쿠키를 삭제하고,
  * 성공 시 Zustand 스토어를 초기화한 뒤 메인 페이지로 이동합니다.
+ *
+ * @example
+ * ```ts
+ * const { handleLogout } = useLogout();
+ * ```
  */
 export const useLogout = () => {
   const router = useRouter();

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/navigation';
+import { bffFetch } from '@/shared/apis/base/bffFetch';
+import { useUserStore } from '@/shared/stores/userStore';
+import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
+
+/**
+ * 로그아웃을 처리하는 훅입니다.
+ * BFF Route Handler를 호출해 HttpOnly 쿠키를 삭제하고,
+ * 성공 시 Zustand 스토어를 초기화한 뒤 메인 페이지로 이동합니다.
+ */
+export const useLogout = () => {
+  const router = useRouter();
+  const { showToast } = useToastStore();
+  const clearSession = useUserStore((state) => state.clearSession);
+
+  const handleLogout = async () => {
+    try {
+      await bffFetch.post('/auth/logout');
+      clearSession('user');
+      showToast('check', '로그아웃 되었습니다.');
+      router.replace('/');
+    } catch {
+      showToast('warning', '로그아웃 중 오류가 발생했습니다.');
+    }
+  };
+
+  return { handleLogout };
+};

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -24,7 +24,7 @@ export const useLogout = () => {
       if (response === null) throw new Error();
       showToast('check', '로그아웃 되었습니다.');
     } catch {
-      showToast('warning', '로그아웃 중 오류가 발생했습니다.');
+      showToast('cancel', '로그아웃 중 오류가 발생했습니다.');
     } finally {
       clearSession('user');
       router.replace('/');

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation';
-import { bffFetch } from '@/shared/apis/base/bffFetch';
+import { logoutUser } from '@/features/auth/apis/auth';
 import { useUserStore } from '@/shared/stores/userStore';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
@@ -20,7 +20,7 @@ export const useLogout = () => {
 
   const handleLogout = async () => {
     try {
-      const response = await bffFetch.post('/auth/logout');
+      const response = await logoutUser();
       if (response === null) throw new Error();
       showToast('check', '로그아웃 되었습니다.');
     } catch {

--- a/src/shared/hooks/useLogout.ts
+++ b/src/shared/hooks/useLogout.ts
@@ -20,12 +20,14 @@ export const useLogout = () => {
 
   const handleLogout = async () => {
     try {
-      await bffFetch.post('/auth/logout');
-      clearSession('user');
+      const response = await bffFetch.post('/auth/logout');
+      if (response === null) throw new Error();
       showToast('check', '로그아웃 되었습니다.');
-      router.replace('/');
     } catch {
       showToast('warning', '로그아웃 중 오류가 발생했습니다.');
+    } finally {
+      clearSession('user');
+      router.replace('/');
     }
   };
 

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -37,6 +37,7 @@ type HeaderProps = {
   isLoggedIn?: boolean;
   user?: AvatarUser;
   className?: string;
+  onLogout: () => void;
 };
 
 /**
@@ -66,7 +67,7 @@ type HeaderProps = {
  * @param props.user - 유저 정보
  * @param props.className - 추가 클래스
  */
-export default function Header({ isLoggedIn = false, user, className }: HeaderProps) {
+export default function Header({ isLoggedIn = false, user, className, onLogout }: HeaderProps) {
   const pathname = usePathname();
   const isScrollThemedPage = pathname === '/' || pathname === '/search';
   const { isScrolled } = useScroll({ isEnabled: isScrollThemedPage });
@@ -81,7 +82,7 @@ export default function Header({ isLoggedIn = false, user, className }: HeaderPr
           <Logo variant={logoVariantByTheme[theme]} className="h-6 md:h-7" />
         </LogoWrapper>
 
-        <HeaderNav theme={theme} isLoggedIn={isLoggedIn} user={user} />
+        <HeaderNav theme={theme} isLoggedIn={isLoggedIn} user={user} onLogout={onLogout} />
       </div>
     </header>
   );

--- a/src/shared/ui/header/HeaderNav.tsx
+++ b/src/shared/ui/header/HeaderNav.tsx
@@ -14,15 +14,17 @@ type HeaderNavProps = {
   theme: HeaderTheme;
   isLoggedIn?: boolean;
   user?: AvatarUser;
+  onLogout: () => void;
 };
 
 type LoggedInActionsProps = {
   theme: HeaderTheme;
   user: AvatarUser;
+  onLogout: () => void;
 };
 
-function LoggedInActions({ theme, user }: LoggedInActionsProps) {
-  return <UserNav theme={theme} user={user} />;
+function LoggedInActions({ theme, user, onLogout }: LoggedInActionsProps) {
+  return <UserNav theme={theme} user={user} onLogout={onLogout} />;
 }
 
 type GuestActionsProps = {
@@ -46,9 +48,9 @@ function GuestActions({ theme }: GuestActionsProps) {
  * @param props.isLoggedIn - 로그인 여부
  * @param props.user - 유저 정보
  */
-export default function HeaderNav({ theme, isLoggedIn = false, user }: HeaderNavProps) {
+export default function HeaderNav({ theme, isLoggedIn = false, user, onLogout }: HeaderNavProps) {
   if (isLoggedIn && user) {
-    return <LoggedInActions theme={theme} user={user} />;
+    return <LoggedInActions theme={theme} user={user} onLogout={onLogout} />;
   }
 
   return <GuestActions theme={theme} />;

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -1,7 +1,9 @@
 import { cva } from 'class-variance-authority';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { NotificationIcon } from '@/shared/assets/icons';
 import type { AvatarUser } from '@/shared/ui/avatar/types';
+import ConfirmDialog from '@/shared/ui/dialog/ConfirmDialog';
 import {
   ActionDropdown,
   ActionDropdownContent,
@@ -68,6 +70,7 @@ type UserNavProps = {
 export default function UserNav({ theme, user, className, onLogout }: UserNavProps) {
   const router = useRouter();
   const handleLogout = onLogout;
+  const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
 
   return (
     <div className={cn('flex items-center gap-5', className)}>
@@ -87,9 +90,20 @@ export default function UserNav({ theme, user, className, onLogout }: UserNavPro
           <ActionDropdownItem onClick={() => router.push('/mypage/info')}>
             마이페이지
           </ActionDropdownItem>
-          <ActionDropdownItem onClick={handleLogout}>로그아웃</ActionDropdownItem>
+          <ActionDropdownItem onClick={() => setIsLogoutModalOpen(true)}>
+            로그아웃
+          </ActionDropdownItem>
         </ActionDropdownContent>
       </ActionDropdown>
+      <ConfirmDialog
+        isOpen={isLogoutModalOpen}
+        onClose={() => setIsLogoutModalOpen(false)}
+        title="로그아웃 하시겠습니까?"
+        confirmText="네"
+        cancelText="아니오"
+        onCancel={() => setIsLogoutModalOpen(false)}
+        onConfirm={handleLogout}
+      />
     </div>
   );
 }

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cva } from 'class-variance-authority';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -1,6 +1,7 @@
 import { cva } from 'class-variance-authority';
 import { useRouter } from 'next/navigation';
 import { NotificationIcon } from '@/shared/assets/icons';
+import { useLogout } from '@/shared/hooks/useLogout';
 import type { AvatarUser } from '@/shared/ui/avatar/types';
 import {
   ActionDropdown,
@@ -44,13 +45,11 @@ const profileNicknameVariants = cva('', {
  * @property theme - 헤더 테마 (`'primary' | 'light'`)
  * @property user - 유저 정보
  * @property className - wrapper에 추가할 클래스
- * @property onLogout - 로그아웃 클릭 시 실행할 콜백
  */
 type UserNavProps = {
   theme: HeaderTheme;
   user: AvatarUser;
   className?: string;
-  onLogout?: () => void;
 };
 
 /**
@@ -65,12 +64,10 @@ type UserNavProps = {
  * @param props.theme - 헤더 테마
  * @param props.user - 유저 정보
  * @param props.className - 추가 클래스
- * @param props.onLogout - 로그아웃 콜백
  */
-export default function UserNav({ theme, user, className, onLogout }: UserNavProps) {
+export default function UserNav({ theme, user, className }: UserNavProps) {
   const router = useRouter();
-  // TODO: 실제 로그아웃 로직(인증 상태/토큰/스토어 초기화 등) 연결
-  const handleLogout = onLogout ?? (() => {});
+  const { handleLogout } = useLogout();
 
   return (
     <div className={cn('flex items-center gap-5', className)}>

--- a/src/shared/ui/header/UserNav.tsx
+++ b/src/shared/ui/header/UserNav.tsx
@@ -1,7 +1,6 @@
 import { cva } from 'class-variance-authority';
 import { useRouter } from 'next/navigation';
 import { NotificationIcon } from '@/shared/assets/icons';
-import { useLogout } from '@/shared/hooks/useLogout';
 import type { AvatarUser } from '@/shared/ui/avatar/types';
 import {
   ActionDropdown,
@@ -50,6 +49,7 @@ type UserNavProps = {
   theme: HeaderTheme;
   user: AvatarUser;
   className?: string;
+  onLogout: () => void;
 };
 
 /**
@@ -65,9 +65,9 @@ type UserNavProps = {
  * @param props.user - 유저 정보
  * @param props.className - 추가 클래스
  */
-export default function UserNav({ theme, user, className }: UserNavProps) {
+export default function UserNav({ theme, user, className, onLogout }: UserNavProps) {
   const router = useRouter();
-  const { handleLogout } = useLogout();
+  const handleLogout = onLogout;
 
   return (
     <div className={cn('flex items-center gap-5', className)}>


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #180

## 체크 사항

- [x]  UI 동작 및 레이아웃 확인
- [x]  콘솔 로그/에러 없음
- [x]  기능 정상 동작
- [x]  팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

헤더 로그아웃 버튼 클릭 시 로그아웃 처리하도록 구현했습니다.
bffFetch 라우트 핸들러를 호출하고 성공 시 사용자 정보 및 세션을 초기화됩니다. (쿠키 삭제는 라우트 핸들러에서 진행)

- 성공 시
    - store clearSession('user') 업데이트
    - 성공 안내 토스트 띄우기
    - 메인 페이지로 이동
- 실패 시
    - 실패 안내 토스트 띄우기

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

(제미나이 리뷰 확인해서 HeaderContainer로 호출 위치 변경했습니당!)
로그아웃 훅 호출 위치가 적절한가용..? 우선 UserNav 컴포넌트에서 직접 호출로 작업해봤습니당
shared에 있는 파일이라서 좀 고민됐는데 HeaderContainer부터 prop 내려주는것도 애매하고 다른 헤더 요소 컴포넌트들도 다 shared에 있어서 계속 고민하다가 UserNav로 결정했습니당