### PR TITLE
[✨ Feat/#209] 알림 router 구현

### DIFF
--- a/src/app/(private)/mypage/reservation-list/page.tsx
+++ b/src/app/(private)/mypage/reservation-list/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import ReservationListView from '@/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView';
 
 export default function ReservationListPage() {
-  return <ReservationListView />;
+  return (
+    <Suspense>
+      <ReservationListView />
+    </Suspense>
+  );
 }

--- a/src/features/notification/ui/Notification.tsx
+++ b/src/features/notification/ui/Notification.tsx
@@ -65,7 +65,7 @@ export default function Notification({
   });
 
   return (
-    <div className="absolute top-[calc(100%+8px)] right-0 layer-dropdown max-h-[340px] w-65 rounded-xl bg-white pt-4 pb-2 shadow-card max-sm:fixed max-sm:top-14 max-sm:right-6 max-sm:left-6 max-sm:w-auto lg:w-92.5">
+    <div className="absolute top-[calc(100%+8px)] right-0 layer-dropdown max-h-85 w-65 rounded-xl bg-white pt-4 pb-2 shadow-card max-sm:fixed max-sm:top-14 max-sm:right-6 max-sm:left-6 max-sm:w-auto lg:w-92.5">
       <div className="flex items-center justify-between border-b border-gray-50 px-4 pb-3">
         <div className="typo-16-bold">알림 {totalCount}개</div>
         {notifications.length > 0 && (

--- a/src/features/notification/ui/NotificationItem.tsx
+++ b/src/features/notification/ui/NotificationItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import type { ParsedNotification } from '@/features/notification/types';
 import { getTimeAgo } from '@/features/notification/utils/getTimeAgo';
 import { DeleteIcon } from '@/shared/assets/icons';
@@ -51,19 +51,12 @@ export default function NotificationItem({
   onDelete,
   lastSeenAtMs,
 }: NotificationItemProps) {
-  const router = useRouter();
-
   const { label, color, reservationListUrl } =
     NOTIFICATION_STATUS_OPTIONS[status as NotificationStatus];
 
   const updatedAtMs = Date.parse(updatedAt);
   const isNew =
     Number.isFinite(updatedAtMs) && (lastSeenAtMs == null || updatedAtMs > lastSeenAtMs);
-
-  /** 상태에 따라 예약 내역 페이지로 이동 */
-  const handleNavigateReservationList = () => {
-    router.push(reservationListUrl);
-  };
 
   return (
     <div className={`p-4 ${isNew ? 'bg-primary-50' : ''}`}>
@@ -82,13 +75,9 @@ export default function NotificationItem({
       </div>
 
       <div className="typo-14-medium text-gray-800">
-        <button
-          type="button"
-          onClick={handleNavigateReservationList}
-          className="cursor-pointer text-left wrap-break-word hover:underline"
-        >
+        <Link href={reservationListUrl} className="block text-left wrap-break-word hover:underline">
           {title} ({date})
-        </button>
+        </Link>
 
         <p>
           예약이 <span className={`font-semibold ${color}`}>{label}</span> 되었어요

--- a/src/features/notification/ui/NotificationItem.tsx
+++ b/src/features/notification/ui/NotificationItem.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import type { ParsedNotification } from '@/features/notification/types';
 import { getTimeAgo } from '@/features/notification/utils/getTimeAgo';
 import { DeleteIcon } from '@/shared/assets/icons';
@@ -16,10 +19,12 @@ const NOTIFICATION_STATUS_OPTIONS = {
   confirmed: {
     label: '승인',
     color: 'text-primary-500',
+    reservationListUrl: '/mypage/reservation-list?status=confirmed',
   },
   declined: {
     label: '거절',
     color: 'text-red-500',
+    reservationListUrl: '/mypage/reservation-list?status=declined',
   },
 } as const;
 
@@ -46,12 +51,19 @@ export default function NotificationItem({
   onDelete,
   lastSeenAtMs,
 }: NotificationItemProps) {
-  const { label, color } =
-    NOTIFICATION_STATUS_OPTIONS[status as keyof typeof NOTIFICATION_STATUS_OPTIONS];
+  const router = useRouter();
+
+  const { label, color, reservationListUrl } =
+    NOTIFICATION_STATUS_OPTIONS[status as NotificationStatus];
 
   const updatedAtMs = Date.parse(updatedAt);
   const isNew =
     Number.isFinite(updatedAtMs) && (lastSeenAtMs == null || updatedAtMs > lastSeenAtMs);
+
+  /** 상태에 따라 예약 내역 페이지로 이동 */
+  const handleNavigateReservationList = () => {
+    router.push(reservationListUrl);
+  };
 
   return (
     <div className={`p-4 ${isNew ? 'bg-primary-50' : ''}`}>
@@ -68,10 +80,16 @@ export default function NotificationItem({
           </button>
         </div>
       </div>
+
       <div className="typo-14-medium text-gray-800">
-        <p className="wrap-break-word">
+        <button
+          type="button"
+          onClick={handleNavigateReservationList}
+          className="cursor-pointer text-left wrap-break-word hover:underline"
+        >
           {title} ({date})
-        </p>
+        </button>
+
         <p>
           예약이 <span className={`font-semibold ${color}`}>{label}</span> 되었어요
         </p>

--- a/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
+++ b/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useMemo } from 'react';
 import {
   MY_RESERVATIONS_PAGE_SIZE,
   useMyReservations,
@@ -14,6 +14,8 @@ import InfiniteScrollSentinel from '@/shared/ui/infinite-scroll/InfiniteScrollSe
 import PageHeader from '@/shared/ui/page-header/PageHeader';
 import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 
+const RESERVATION_LIST_PATH = '/mypage/reservation-list';
+
 const EMPTY_MAIN_TEXT_BY_STATUS: Record<ReservationStatus | '', string> = {
   '': '아직 예약한 체험이 없어요.\n새로운 체험을 예약해보세요!',
   pending: '예약 완료 내역이 없습니다.\n새로운 체험을 예약해보세요!',
@@ -23,12 +25,48 @@ const EMPTY_MAIN_TEXT_BY_STATUS: Record<ReservationStatus | '', string> = {
   completed: '아직 완료된 내역이 없어요.',
 };
 
+const RESERVATION_STATUS_VALUES = [
+  'pending',
+  'confirmed',
+  'declined',
+  'canceled',
+  'completed',
+] satisfies ReservationStatus[];
+
+const isReservationStatus = (value: string | null): value is ReservationStatus => {
+  return value !== null && RESERVATION_STATUS_VALUES.includes(value as ReservationStatus);
+};
+
+const getReservationListUrl = (status: ReservationStatus | '', searchParams: URLSearchParams) => {
+  const params = new URLSearchParams(searchParams.toString());
+
+  if (status) {
+    params.set('status', status);
+  } else {
+    params.delete('status');
+  }
+
+  const queryString = params.toString();
+
+  return queryString ? `${RESERVATION_LIST_PATH}?${queryString}` : RESERVATION_LIST_PATH;
+};
+
 export default function ReservationListView() {
   const router = useRouter();
-  const [selectedStatus, setSelectedStatus] = useState<ReservationStatus | ''>('pending');
+  const searchParams = useSearchParams();
+
+  const statusParam = searchParams.get('status');
+
+  const selectedStatus: ReservationStatus = isReservationStatus(statusParam)
+    ? statusParam
+    : 'pending';
+
+  const handleSelectStatus = (status: ReservationStatus | '') => {
+    router.replace(getReservationListUrl(status, searchParams));
+  };
 
   const { query } = useMyReservations({
-    status: (selectedStatus || undefined) as MyReservationStatus | undefined,
+    status: selectedStatus as MyReservationStatus,
     size: MY_RESERVATIONS_PAGE_SIZE,
   });
 
@@ -53,7 +91,8 @@ export default function ReservationListView() {
           description="예약내역 변경 및 취소할 수 있습니다."
           onBack={() => router.back()}
         />
-        <StatusFilter selectedStatus={selectedStatus} onSelectStatus={setSelectedStatus} />
+
+        <StatusFilter selectedStatus={selectedStatus} onSelectStatus={handleSelectStatus} />
       </div>
 
       <ReservationListSection


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #209 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1. 알림 → 예약내역 카테고리 이동 기능 추가
알림 클릭 시 상태(confirmed, declined)에 따라 예약내역 페이지로 이동하도록 구현했습니다
NotificationItem에서 status 기반으로 URL을 분기 처리했습니다
```
/mypage/reservation-list?status=confirmed
/mypage/reservation-list?status=declined
```

### 2. 예약내역 페이지 필터 상태 URL 기반으로 리팩토링
- 기존에는 useState로 필터 상태를 관리했으나, URL(query param)을 source of truth로 사용하는 구조로 변경했습니다.

**주요 변경 사항**
- useSearchParams로 status 읽어서 필터 초기값 설정
- 필터 클릭 시 router.replace로 URL 동기화
- useState 제거
```
const selectedStatus = isReservationStatus(statusParam)
  ? statusParam
  : 'pending';
```
### 3. 필터 클릭 시 URL 동기화 처리
- StatusFilter에서 상태 변경 시 URL이 함께 변경되도록 수정했습니다
`router.replace('/mypage/reservation-list?status=...');`

### Param 기반으로 변경한 이유
- 알림 → 예약내역 이동 시 필터 상태 유지 문제 해결
- UI 상태와 URL 간 불일치 제거
- 새로고침 / 뒤로가기 시에도 동일한 상태 유지
- 상태 관리 단순화 (state 제거)


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
