### PR TITLE
[✨ Feat/#211] 예약 내역/체험 관리 카드 상세페이지 이동 구현

### DIFF
--- a/src/features/my-page/my-activity/ui/my-activity-card/MyActivityCard.stories.tsx
+++ b/src/features/my-page/my-activity/ui/my-activity-card/MyActivityCard.stories.tsx
@@ -5,6 +5,16 @@ const meta: Meta<typeof MyActivityCard> = {
   title: 'Features/Card/MyActivityCard',
   component: MyActivityCard,
   tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        push: () => {},
+        replace: () => {},
+        back: () => {},
+      },
+    },
+  },
 };
 
 export default meta;
@@ -47,16 +57,11 @@ const mockActivities = [
     price: 99000,
   },
 ];
+
 // 내 체험 관리 카드
 export const MyActivity: Story = {
   args: {
-    data: {
-      id: 1,
-      title: '제목이 아주 길어지는 경우에는 말줄임표가 적용됩니다',
-      reviewCount: 120,
-      rating: 3.5,
-      price: 25000,
-    },
+    data: mockActivities[0],
   },
   render: () => (
     <div className="flex w-100 flex-col gap-5 md:w-130 md:gap-5 lg:w-170">

--- a/src/features/my-page/my-activity/ui/my-activity-card/MyActivityCard.tsx
+++ b/src/features/my-page/my-activity/ui/my-activity-card/MyActivityCard.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import BaseCardImage from '@/shared/ui/card/base/BaseCardImage';
 import { cardImageStyles, cardWrapStyles } from '@/shared/ui/card/cardStyles';
 import { cn } from '@/shared/utils/cn';
@@ -30,17 +33,26 @@ export type MyActivityCardProps = {
  * ```
  */
 export default function MyActivityCard({ data }: MyActivityCardProps) {
-  const { title, bannerImageUrl } = data;
+  const router = useRouter();
+  const { id, title, bannerImageUrl } = data;
+
+  const handleClickCard = () => {
+    router.push(`/activity/${id}`);
+  };
 
   return (
-    <div className={cn('flex items-center rounded-3xl', cardWrapStyles)}>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClickCard}
+      className={cn('flex cursor-pointer items-center rounded-3xl', cardWrapStyles)}
+    >
       {/* 이미지 영역 */}
       <BaseCardImage
         bannerImageUrl={bannerImageUrl}
         alt={title}
         containerClassName={cardImageStyles}
       />
-
       {/* 정보 영역 */}
       <div className="relative layer-base w-full">
         <MyActivityCardInfo data={data} />

--- a/src/features/my-page/my-activity/ui/my-activity-card/MyActivityCard.tsx
+++ b/src/features/my-page/my-activity/ui/my-activity-card/MyActivityCard.tsx
@@ -36,15 +36,19 @@ export default function MyActivityCard({ data }: MyActivityCardProps) {
   const router = useRouter();
   const { id, title, bannerImageUrl } = data;
 
-  const handleClickCard = () => {
-    router.push(`/activity/${id}`);
+  const handleClickCard = (e: React.MouseEvent | React.KeyboardEvent) => {
+    // 내부의 버튼이나 링크 클릭 시에는 카드 전체 클릭 이벤트가 발생하지 않도록 방지
+    if ((e.target as HTMLElement).closest('button, a')) return;
+    if (e.type === 'click' || (e as React.KeyboardEvent).key === 'Enter') {
+      router.push(`/activity/${id}`);
+    }
   };
-
   return (
     <div
       role="button"
       tabIndex={0}
       onClick={handleClickCard}
+      onKeyDown={handleClickCard}
       className={cn('flex cursor-pointer items-center rounded-3xl', cardWrapStyles)}
     >
       {/* 이미지 영역 */}

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.stories.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.stories.tsx
@@ -6,6 +6,16 @@ const meta: Meta<typeof ReservationCard> = {
   title: 'Features/Card/ReservationCard',
   component: ReservationCard,
   tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        push: () => {},
+        replace: () => {},
+        back: () => {},
+      },
+    },
+  },
 };
 
 export default meta;
@@ -133,12 +143,13 @@ const mockReservations: MyReservation[] = [
     updatedAt: '2026-05-01T00:00:00.000Z',
   },
 ];
+
 // 예약 내역 카드
 export const Reservation: Story = {
   render: () => (
     <div className="flex w-100 flex-col gap-5 md:w-130 md:gap-5 lg:w-170">
       {mockReservations.map((data) => (
-        <ReservationCard key={data.activity.id} data={data} />
+        <ReservationCard key={data.id} data={data} />
       ))}
     </div>
   ),

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+import { useRouter } from 'next/navigation';
 import type { MyReservation } from '@/features/reservation/types';
 import BaseCardImage from '@/shared/ui/card/base/BaseCardImage';
 import { cardImageStyles, cardWrapStyles } from '@/shared/ui/card/cardStyles';
@@ -20,8 +22,19 @@ export type ReservationCardProps = {
  * ```
  */
 export default function ReservationCard({ data }: ReservationCardProps) {
+  const router = useRouter();
+
+  const handleClickCard = () => {
+    router.push(`/activity/${data.activity.id}`);
+  };
+
   return (
-    <div className={cn('flex items-center rounded-3xl', cardWrapStyles)}>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClickCard}
+      className={cn('flex cursor-pointer items-center rounded-3xl', cardWrapStyles)}
+    >
       {/* 이미지 */}
       <BaseCardImage
         containerClassName={cardImageStyles}

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCard.tsx
@@ -24,15 +24,19 @@ export type ReservationCardProps = {
 export default function ReservationCard({ data }: ReservationCardProps) {
   const router = useRouter();
 
-  const handleClickCard = () => {
-    router.push(`/activity/${data.activity.id}`);
+  const handleClickCard = (e: React.MouseEvent | React.KeyboardEvent) => {
+    // 내부의 버튼이나 링크 클릭 시에는 카드 전체 클릭 이벤트가 발생하지 않도록 방지
+    if ((e.target as HTMLElement).closest('button, a')) return;
+    if (e.type === 'click' || (e as React.KeyboardEvent).key === 'Enter') {
+      router.push(`/activity/${data.activity.id}`);
+    }
   };
-
   return (
     <div
       role="button"
       tabIndex={0}
       onClick={handleClickCard}
+      onKeyDown={handleClickCard}
       className={cn('flex cursor-pointer items-center rounded-3xl', cardWrapStyles)}
     >
       {/* 이미지 */}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #211 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 예약 내역 카드를 클릭 시 해당 상세 페이지로 이동
- 체험 관리 카드를 클릭 시 해당 상세 페이지로 이동 

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
