### PR TITLE
[✨Feat/#227] 예약 승인 시 자동 거절 안내 모달 추가

### DIFF
--- a/src/features/my-page/reservation-status/ui/pannel/ReservationCard.tsx
+++ b/src/features/my-page/reservation-status/ui/pannel/ReservationCard.tsx
@@ -34,6 +34,7 @@ export default function ReservationCard({
 }: ReservationCardProps) {
   const [loadingType, setLoadingType] = useState<'confirm' | 'decline' | null>(null);
   const [isDeclineDialogOpen, setIsDeclineDialogOpen] = useState(false);
+  const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
 
   const isPending = reservation.status === 'pending';
   const isConfirmed = reservation.status === 'confirmed';
@@ -84,7 +85,7 @@ export default function ReservationCard({
             theme="primary"
             size="sm"
             className="h-full flex-1"
-            onClick={handleConfirm}
+            onClick={() => setIsConfirmDialogOpen(true)}
             isLoading={loadingType === 'confirm'}
             disabled={isAnyLoading}
           >
@@ -102,6 +103,16 @@ export default function ReservationCard({
           </Button>
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={isConfirmDialogOpen}
+        onClose={() => setIsConfirmDialogOpen(false)}
+        title="예약을 승인할까요?"
+        description="같은 시간대의 나머지 예약은 자동으로 거절됩니다."
+        confirmText="승인하기"
+        cancelText="취소"
+        onConfirm={handleConfirm}
+      />
 
       <ConfirmDialog
         isOpen={isDeclineDialogOpen}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #227 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 예약 내역 승인 시 다른 예약 내역은 자동으로 거절 처리 되기 때문에 모달을 활용해 안내로 표시

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
