### PR TITLE
[✨Feat/#215] 카카오톡 공유, url 복사 기능

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,6 +43,12 @@ export default function RootLayout({
               src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_KEY}&libraries=services&autoload=false`}
               strategy="afterInteractive"
             />
+            <Script
+              src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js"
+              integrity="sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4"
+              crossOrigin="anonymous"
+              strategy="afterInteractive"
+            />
             <ToastContainer />
           </AuthTokenRefreshProvider>
         </QueryProvider>

--- a/src/features/activity/activity-detail/hooks/useActivityShare.ts
+++ b/src/features/activity/activity-detail/hooks/useActivityShare.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
+
+export const useActivityShare = () => {
+  const { showToast } = useToastStore();
+
+  const handleCopyUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      showToast('check', 'URL이 복사되었습니다.');
+    } catch {
+      showToast('cancel', 'URL 복사에 실패했습니다.');
+    }
+  };
+
+  const handleKakaoShare = (title: string, description: string, bannerImageUrl: string) => {
+    if (!window.Kakao?.isInitialized()) {
+      showToast('cancel', '카카오 공유 기능을 사용할 수 없습니다. 잠시 후 다시 시도해 주세요.');
+      return;
+    }
+
+    window.Kakao.Share.sendDefault({
+      objectType: 'feed',
+      content: {
+        title,
+        description,
+        imageUrl: bannerImageUrl,
+        link: {
+          mobileWebUrl: window.location.href,
+          webUrl: window.location.href,
+        },
+      },
+      buttons: [
+        {
+          title: '체험 보러가기',
+          link: {
+            mobileWebUrl: window.location.href,
+            webUrl: window.location.href,
+          },
+        },
+      ],
+    });
+  };
+
+  return { handleCopyUrl, handleKakaoShare };
+};

--- a/src/features/activity/activity-detail/hooks/useCopyUrl.tsx
+++ b/src/features/activity/activity-detail/hooks/useCopyUrl.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
+
+export const useCopyUrl = () => {
+  const { showToast } = useToastStore();
+
+  const handleCopyUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      showToast('check', 'URL이 복사되었습니다.');
+    } catch {
+      showToast('cancel', 'URL 복사에 실패했습니다.');
+    }
+  };
+
+  return { handleCopyUrl };
+};

--- a/src/features/activity/activity-detail/hooks/useKakaoShare.ts
+++ b/src/features/activity/activity-detail/hooks/useKakaoShare.ts
@@ -2,17 +2,8 @@
 
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
-export const useActivityShare = () => {
+export const useKakaoShare = () => {
   const { showToast } = useToastStore();
-
-  const handleCopyUrl = async () => {
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      showToast('check', 'URL이 복사되었습니다.');
-    } catch {
-      showToast('cancel', 'URL 복사에 실패했습니다.');
-    }
-  };
 
   const handleKakaoShare = (title: string, description: string, bannerImageUrl: string) => {
     if (!window.Kakao?.isInitialized()) {
@@ -43,5 +34,5 @@ export const useActivityShare = () => {
     });
   };
 
-  return { handleCopyUrl, handleKakaoShare };
+  return { handleKakaoShare };
 };

--- a/src/features/activity/activity-detail/ui/activity-info/ActivityDetail.tsx
+++ b/src/features/activity/activity-detail/ui/activity-info/ActivityDetail.tsx
@@ -31,6 +31,8 @@ export default function ActivityDetail({ activity }: ActivityDetailProps) {
         rating={activity.rating}
         reviewCount={activity.reviewCount}
         address={activity.address}
+        description={activity.description}
+        bannerImageUrl={activity.bannerImageUrl}
         className="mt-7"
       />
       {/* 탭바 */}

--- a/src/features/activity/activity-detail/ui/activity-info/ActivityInfo.tsx
+++ b/src/features/activity/activity-detail/ui/activity-info/ActivityInfo.tsx
@@ -13,6 +13,8 @@ type ActivityInfoProps = {
   rating: number;
   reviewCount: number;
   address: string;
+  description: string;
+  bannerImageUrl: string;
   className?: string;
 };
 
@@ -42,6 +44,8 @@ export default function ActivityInfo({
   rating,
   reviewCount,
   address,
+  description,
+  bannerImageUrl,
   className,
 }: ActivityInfoProps) {
   return (
@@ -71,7 +75,7 @@ export default function ActivityInfo({
       {/* 주소, 공유 기능 */}
       <div className="flex items-center justify-between">
         <ActivityAddress address={address} />
-        <ActivityShare />
+        <ActivityShare title={title} description={description} bannerImageUrl={bannerImageUrl} />
       </div>
     </div>
   );

--- a/src/features/activity/activity-detail/ui/activity-info/ActivityInfo.tsx
+++ b/src/features/activity/activity-detail/ui/activity-info/ActivityInfo.tsx
@@ -3,6 +3,7 @@ import ActivityKebabMenu from '@/features/activity/activity-detail/ui/activity-i
 import { StarIcon } from '@/shared/assets/icons';
 import Title from '@/shared/ui/title/Title';
 import { cn } from '@/shared/utils/cn';
+import ActivityShare from '../share/ActivityShare';
 
 type ActivityInfoProps = {
   id: number;
@@ -67,10 +68,10 @@ export default function ActivityInfo({
           {rating} ({reviewCount})
         </span>
       </div>
-      {/* 주소 */}
+      {/* 주소, 공유 기능 */}
       <div className="flex items-center justify-between">
         <ActivityAddress address={address} />
-        {/* TODO: 공유 버튼 영역 */}
+        <ActivityShare />
       </div>
     </div>
   );

--- a/src/features/activity/activity-detail/ui/activity-info/ActivityInfo.tsx
+++ b/src/features/activity/activity-detail/ui/activity-info/ActivityInfo.tsx
@@ -1,9 +1,9 @@
 import ActivityAddress from '@/features/activity/activity-detail/ui/activity-info/ActivityAddress';
 import ActivityKebabMenu from '@/features/activity/activity-detail/ui/activity-info/ActivityKebabMenu';
+import ActivityShare from '@/features/activity/activity-detail/ui/share/ActivityShare';
 import { StarIcon } from '@/shared/assets/icons';
 import Title from '@/shared/ui/title/Title';
 import { cn } from '@/shared/utils/cn';
-import ActivityShare from '../share/ActivityShare';
 
 type ActivityInfoProps = {
   id: number;

--- a/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
+++ b/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
@@ -27,8 +27,12 @@ export default function ActivityShare({ title, description, bannerImageUrl }: Ac
   const { showToast } = useToastStore();
 
   const handleCopyUrl = async () => {
-    await navigator.clipboard.writeText(window.location.href);
-    showToast('check', 'URL이 복사되었습니다.');
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      showToast('check', 'URL이 복사되었습니다.');
+    } catch {
+      showToast('cancel', 'URL 복사에 실패했습니다.');
+    }
   };
 
   const handleKakaoShare = () => {

--- a/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
+++ b/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
@@ -37,7 +37,7 @@ export default function ActivityShare({ title, description, bannerImageUrl }: Ac
 
   const handleKakaoShare = () => {
     if (!window.Kakao) {
-      showToast('cancel', '카카오 SDK를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
+      showToast('cancel', '카카오 공유 기능을 사용할 수 없습니다. 잠시 후 다시 시도해 주세요.');
       return;
     }
     if (!window.Kakao.isInitialized()) {

--- a/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
+++ b/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useActivityShare } from '@/features/activity/activity-detail/hooks/useActivityShare';
+import { useCopyUrl } from '@/features/activity/activity-detail/hooks/useCopyUrl';
+import { useKakaoShare } from '@/features/activity/activity-detail/hooks/useKakaoShare';
 import { KakaoIcon, LinkIcon } from '@/shared/assets/icons';
 
 type ActivityShareProps = {
@@ -24,7 +25,8 @@ type ActivityShareProps = {
  * ```
  */
 export default function ActivityShare({ title, description, bannerImageUrl }: ActivityShareProps) {
-  const { handleCopyUrl, handleKakaoShare } = useActivityShare();
+  const { handleCopyUrl } = useCopyUrl();
+  const { handleKakaoShare } = useKakaoShare();
 
   return (
     <div className="flex items-center gap-3">

--- a/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
+++ b/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
@@ -32,6 +32,10 @@ export default function ActivityShare({ title, description, bannerImageUrl }: Ac
   };
 
   const handleKakaoShare = () => {
+    if (!window.Kakao) {
+      showToast('cancel', '카카오 SDK를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
+      return;
+    }
     if (!window.Kakao.isInitialized()) {
       window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_MAP_KEY!);
     }

--- a/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
+++ b/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { LinkIcon } from '@/shared/assets/icons';
+import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
+
+/**
+ * 체험 공유 컴포넌트입니다.
+ *
+ * URL 복사 및 카카오톡 공유 기능을 제공합니다.
+ *
+ * @example
+ * ```tsx
+ * <ActivityShare />
+ * ```
+ */
+export default function ActivityShare() {
+  const { showToast } = useToastStore();
+
+  const handleCopyUrl = async () => {
+    await navigator.clipboard.writeText(window.location.href);
+    showToast('check', 'URL이 복사되었습니다.');
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <button type="button" onClick={handleCopyUrl} aria-label="URL 복사">
+        <LinkIcon />
+      </button>
+    </div>
+  );
+}

--- a/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
+++ b/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
@@ -16,7 +16,11 @@ type ActivityShareProps = {
  *
  * @example
  * ```tsx
- * <ActivityShare />
+ * <ActivityShare
+ *   title={title}
+ *   description={description}
+ *   bannerImageUrl={bannerImageUrl}
+ * />
  * ```
  */
 export default function ActivityShare({ title, description, bannerImageUrl }: ActivityShareProps) {

--- a/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
+++ b/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { LinkIcon } from '@/shared/assets/icons';
+import { KakaoIcon, LinkIcon } from '@/shared/assets/icons';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
+
+type ActivityShareProps = {
+  title: string;
+  description: string;
+  bannerImageUrl: string;
+};
 
 /**
  * 체험 공유 컴포넌트입니다.
@@ -13,7 +19,7 @@ import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
  * <ActivityShare />
  * ```
  */
-export default function ActivityShare() {
+export default function ActivityShare({ title, description, bannerImageUrl }: ActivityShareProps) {
   const { showToast } = useToastStore();
 
   const handleCopyUrl = async () => {
@@ -21,10 +27,46 @@ export default function ActivityShare() {
     showToast('check', 'URL이 복사되었습니다.');
   };
 
+  const handleKakaoShare = () => {
+    if (!window.Kakao.isInitialized()) {
+      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_MAP_KEY!);
+    }
+
+    window.Kakao.Share.sendDefault({
+      objectType: 'feed',
+      content: {
+        title,
+        description,
+        imageUrl: bannerImageUrl,
+        link: {
+          mobileWebUrl: window.location.href,
+          webUrl: window.location.href,
+        },
+      },
+      buttons: [
+        {
+          title: '체험 보러가기',
+          link: {
+            mobileWebUrl: window.location.href,
+            webUrl: window.location.href,
+          },
+        },
+      ],
+    });
+  };
+
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-3">
       <button type="button" onClick={handleCopyUrl} aria-label="URL 복사">
         <LinkIcon />
+      </button>
+      <button
+        type="button"
+        onClick={handleKakaoShare}
+        aria-label="카카오톡 공유"
+        className="flex h-9 w-9 items-center justify-center rounded-full bg-kakao-bg"
+      >
+        <KakaoIcon />
       </button>
     </div>
   );

--- a/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
+++ b/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { useActivityShare } from '@/features/activity/activity-detail/hooks/useActivityShare';
 import { KakaoIcon, LinkIcon } from '@/shared/assets/icons';
-import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
 type ActivityShareProps = {
   title: string;
@@ -24,48 +24,7 @@ type ActivityShareProps = {
  * ```
  */
 export default function ActivityShare({ title, description, bannerImageUrl }: ActivityShareProps) {
-  const { showToast } = useToastStore();
-
-  const handleCopyUrl = async () => {
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      showToast('check', 'URL이 복사되었습니다.');
-    } catch {
-      showToast('cancel', 'URL 복사에 실패했습니다.');
-    }
-  };
-
-  const handleKakaoShare = () => {
-    if (!window.Kakao) {
-      showToast('cancel', '카카오 공유 기능을 사용할 수 없습니다. 잠시 후 다시 시도해 주세요.');
-      return;
-    }
-    if (!window.Kakao.isInitialized()) {
-      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_MAP_KEY!);
-    }
-
-    window.Kakao.Share.sendDefault({
-      objectType: 'feed',
-      content: {
-        title,
-        description,
-        imageUrl: bannerImageUrl,
-        link: {
-          mobileWebUrl: window.location.href,
-          webUrl: window.location.href,
-        },
-      },
-      buttons: [
-        {
-          title: '체험 보러가기',
-          link: {
-            mobileWebUrl: window.location.href,
-            webUrl: window.location.href,
-          },
-        },
-      ],
-    });
-  };
+  const { handleCopyUrl, handleKakaoShare } = useActivityShare();
 
   return (
     <div className="flex items-center gap-3">
@@ -74,7 +33,7 @@ export default function ActivityShare({ title, description, bannerImageUrl }: Ac
       </button>
       <button
         type="button"
-        onClick={handleKakaoShare}
+        onClick={() => handleKakaoShare(title, description, bannerImageUrl)}
         aria-label="카카오톡 공유"
         className="flex h-9 w-9 items-center justify-center rounded-full bg-kakao-bg"
       >

--- a/src/shared/types/global.d.ts
+++ b/src/shared/types/global.d.ts
@@ -111,6 +111,32 @@ declare global {
       Postcode: KakaoPostcodeConstructor;
       maps: KakaoMaps;
     };
+    // 카카오톡 공유
+    Kakao: {
+      init: (key: string) => void;
+      isInitialized: () => boolean;
+      Share: {
+        sendDefault: (options: {
+          objectType: string;
+          content: {
+            title: string;
+            description?: string;
+            imageUrl?: string;
+            link: {
+              mobileWebUrl: string;
+              webUrl: string;
+            };
+          };
+          buttons?: Array<{
+            title: string;
+            link: {
+              mobileWebUrl: string;
+              webUrl: string;
+            };
+          }>;
+        }) => void;
+      };
+    };
   }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #215 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### URL 복사 및 카카오톡 공유 기능 구현
* ActivityShare — URL 복사 및 카카오톡 공유 버튼

링크 아이콘 클릭 시 현재 페이지 URL 클립보드 복사
카카오 아이콘 클릭 시 체험 제목, 설명, 배너 이미지 포함한 카카오톡 공유

### 스크린샷 (선택)
<img width="645" height="186" alt="image" src="https://github.com/user-attachments/assets/5d54887d-59ce-4659-85b4-232953d189c1" />
<img width="343" height="352" alt="image" src="https://github.com/user-attachments/assets/87295162-f777-488c-abc8-faa6a9af9a6d" />
<img width="317" height="99" alt="image" src="https://github.com/user-attachments/assets/049e1e44-abcc-49b3-9fdc-fa2fcfda930e" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
