### PR TITLE
[✨ Feat/#182] 예약 내역/체험 관리 Delete API 연결

### DIFF
--- a/src/app/(public)/(explore)/activity/[id]/page.tsx
+++ b/src/app/(public)/(explore)/activity/[id]/page.tsx
@@ -17,16 +17,12 @@ export default async function ActivityDetailPage({ params }: Props) {
     notFound();
   }
 
-  const activity = await (async () => {
-    try {
-      return await getActivityDetail(activityId);
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 404) {
-        notFound();
-      }
-      throw error;
+  const activity = await getActivityDetail(activityId).catch((error) => {
+    if (error instanceof ApiError && error.status === 404) {
+      notFound();
     }
-  })();
+    throw error;
+  });
 
   if (!activity) notFound();
 

--- a/src/app/(public)/(explore)/activity/[id]/page.tsx
+++ b/src/app/(public)/(explore)/activity/[id]/page.tsx
@@ -3,6 +3,7 @@ import ActivityDetail from '@/features/activity/activity-detail/ui/activity-info
 import { getActivityDetail } from '@/features/activity/apis';
 import ReservationBar from '@/features/reservation/activity-panel/ui/ReservationBar';
 import ReservationWidget from '@/features/reservation/activity-panel/ui/ReservationWidget';
+import { ApiError } from '@/shared/apis/apiError';
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -16,7 +17,16 @@ export default async function ActivityDetailPage({ params }: Props) {
     notFound();
   }
 
-  const activity = await getActivityDetail(activityId);
+  const activity = await (async () => {
+    try {
+      return await getActivityDetail(activityId);
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        notFound();
+      }
+      throw error;
+    }
+  })();
 
   if (!activity) notFound();
 

--- a/src/features/my-page/common/mutations/useDeleteActivity.ts
+++ b/src/features/my-page/common/mutations/useDeleteActivity.ts
@@ -17,7 +17,7 @@ export const useDeleteActivity = () => {
 
       queryClient.setQueriesData<
         InfiniteData<GetMyActivitiesResponse, number | undefined> | undefined
-      >({ queryKey: ['my-activities', 'infinite'] }, (old) => {
+      >({ queryKey: ['my-activities'] }, (old) => {
         if (!old) return old;
 
         const nextPages = old.pages.map((page) => {

--- a/src/features/my-page/common/mutations/useDeleteActivity.ts
+++ b/src/features/my-page/common/mutations/useDeleteActivity.ts
@@ -1,8 +1,47 @@
-import { useMutation } from '@tanstack/react-query';
+import type { InfiniteData, QueryKey } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteActivity } from '@/features/my-page/apis';
+import type { GetMyActivitiesResponse } from '@/features/my-page/types';
 
 export const useDeleteActivity = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
-    mutationFn: (id: number) => deleteActivity(id),
+    mutationFn: (activityId: number) => deleteActivity(activityId),
+    onMutate: async (activityId) => {
+      await queryClient.cancelQueries({ queryKey: ['my-activities'] });
+
+      const previousQueries = queryClient.getQueriesData<
+        InfiniteData<GetMyActivitiesResponse, number | undefined>
+      >({ queryKey: ['my-activities'] });
+
+      queryClient.setQueriesData<
+        InfiniteData<GetMyActivitiesResponse, number | undefined> | undefined
+      >({ queryKey: ['my-activities', 'infinite'] }, (old) => {
+        if (!old) return old;
+
+        const nextPages = old.pages.map((page) => {
+          const activities = (page.activities ?? []).filter((a) => a.id !== activityId);
+          const removedCount = (page.activities?.length ?? 0) - activities.length;
+          const totalCount = Math.max(0, (page.totalCount ?? 0) - removedCount);
+          return { ...page, activities, totalCount };
+        });
+
+        return { ...old, pages: nextPages };
+      });
+
+      queryClient.removeQueries({ queryKey: ['my-activities', activityId] });
+
+      return { previousQueries };
+    },
+    onError: (_error, _activityId, context) => {
+      context?.previousQueries?.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey as QueryKey, data);
+      });
+    },
+    onSettled: (_data, _error, activityId) => {
+      queryClient.removeQueries({ queryKey: ['my-activities', activityId] });
+      queryClient.invalidateQueries({ queryKey: ['my-activities'] });
+    },
   });
 };

--- a/src/features/my-page/common/ui/DeleteActivityDialog.tsx
+++ b/src/features/my-page/common/ui/DeleteActivityDialog.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRouter } from 'next/navigation';
 import { useDeleteActivity } from '@/features/my-page/common/mutations/useDeleteActivity';
 import ConfirmDialog from '@/shared/ui/dialog/ConfirmDialog';

--- a/src/features/my-page/common/ui/DeleteActivityDialog.tsx
+++ b/src/features/my-page/common/ui/DeleteActivityDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useDeleteActivity } from '@/features/my-page/common/mutations/useDeleteActivity';
+import { ApiError } from '@/shared/apis/apiError';
 import ConfirmDialog from '@/shared/ui/dialog/ConfirmDialog';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
@@ -32,6 +33,17 @@ export default function DeleteActivityDialog({ id, isOpen, onClose }: DeleteActi
             router.push('/mypage/activity');
           },
           onError: (error) => {
+            if (error instanceof ApiError) {
+              if (error.status === 401) {
+                showToast('cancel', '로그인이 필요합니다.');
+                router.push('/login');
+                return;
+              }
+
+              showToast('cancel', error.message);
+              return;
+            }
+
             const message = error instanceof Error ? error.message : '체험 삭제에 실패했습니다.';
             showToast('cancel', message);
           },

--- a/src/features/my-page/my-activity/ui/MyActivityCreateButton.tsx
+++ b/src/features/my-page/my-activity/ui/MyActivityCreateButton.tsx
@@ -25,7 +25,7 @@ export default function MyActivityCreateButton() {
         aria-label="체험 등록하기"
         className="md:hidden"
       >
-        <PlusIcon />
+        <PlusIcon className="h-6 w-6" />
       </Button>
     </>
   );

--- a/src/features/reservation/apis.ts
+++ b/src/features/reservation/apis.ts
@@ -1,6 +1,8 @@
 import type {
+  CancelMyReservationRequestBody,
   CreateMyReservationReviewRequestBody,
   GetMyReservationsQuery,
+  MyReservationItem,
 } from '@/features/reservation/types';
 import {
   CreateMyReservationReviewRequestBodySchema,
@@ -13,6 +15,13 @@ export const getMyReservations = async (query?: GetMyReservationsQuery) => {
   const data = await bffFetch.get<unknown>('/my-reservations', query);
   if (!data) return null;
   return GetMyReservationsResponseSchema.parse(data);
+};
+
+export const cancelMyReservation = async (reservationId: number) => {
+  const body: CancelMyReservationRequestBody = { status: 'canceled' };
+  const data = await bffFetch.patch<MyReservationItem>(`/my-reservations/${reservationId}`, body);
+  if (!data) throw new Error('예약 취소에 실패했습니다.');
+  return data;
 };
 
 export const createMyReservationReview = async (

--- a/src/features/reservation/reservation-list/mutations/useCancelMyReservation.ts
+++ b/src/features/reservation/reservation-list/mutations/useCancelMyReservation.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import type { InfiniteData, QueryKey } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { cancelMyReservation } from '@/features/reservation/apis';
+import type { GetMyReservationsResponse } from '@/features/reservation/types';
+
+export const useCancelMyReservation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (reservationId: number) => cancelMyReservation(reservationId),
+    onMutate: async (reservationId) => {
+      await queryClient.cancelQueries({ queryKey: ['my-reservations'] });
+
+      const previousQueries = queryClient.getQueriesData<
+        InfiniteData<GetMyReservationsResponse, number | undefined>
+      >({ queryKey: ['my-reservations'] });
+
+      queryClient.setQueriesData<
+        InfiniteData<GetMyReservationsResponse, number | undefined> | undefined
+      >({ queryKey: ['my-reservations'] }, (old) => {
+        if (!old) return old;
+
+        const nextPages = old.pages.map((page) => ({
+          ...page,
+          reservations: page.reservations.map((r) =>
+            r.id === reservationId ? { ...r, status: 'canceled' as const } : r
+          ),
+        }));
+
+        return { ...old, pages: nextPages };
+      });
+
+      return { previousQueries };
+    },
+    onError: (_error, _reservationId, context) => {
+      context?.previousQueries?.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey as QueryKey, data);
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['my-reservations'] });
+    },
+  });
+};

--- a/src/features/reservation/reservation-list/ui/CancelReservationDialog.tsx
+++ b/src/features/reservation/reservation-list/ui/CancelReservationDialog.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCancelMyReservation } from '@/features/reservation/reservation-list/mutations/useCancelMyReservation';
+import { ApiError } from '@/shared/apis/apiError';
+import ConfirmDialog from '@/shared/ui/dialog/ConfirmDialog';
+import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
+
+type CancelReservationDialogProps = {
+  reservationId: number;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export default function CancelReservationDialog({
+  reservationId,
+  isOpen,
+  onClose,
+}: CancelReservationDialogProps) {
+  const router = useRouter();
+  const { mutate: cancelReservation } = useCancelMyReservation();
+  const { showToast } = useToastStore();
+
+  return (
+    <ConfirmDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="예약을 취소하시겠어요?"
+      description="취소하면 해당 예약은 즉시 무효 처리됩니다."
+      confirmText="취소하기"
+      cancelText="아니오"
+      onCancel={onClose}
+      onConfirm={() => {
+        cancelReservation(reservationId, {
+          onSuccess: () => {
+            showToast('check', '예약이 취소되었습니다.');
+          },
+          onError: (error) => {
+            if (error instanceof ApiError) {
+              if (error.status === 401) {
+                showToast('cancel', '로그인이 필요합니다.');
+                router.push('/login');
+                return;
+              }
+              showToast('cancel', error.message);
+              return;
+            }
+
+            const message = error instanceof Error ? error.message : '예약 취소에 실패했습니다.';
+            showToast('cancel', message);
+          },
+        });
+        onClose();
+      }}
+    />
+  );
+}

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
@@ -65,6 +65,7 @@ export default function ReservationCardInfo({ data }: ReservationCardProps) {
           type="reservation"
           status={status}
           reviewSubmitted={reviewSubmitted}
+          reservationId={id}
           activityId={activity.id}
           onReviewClick={() => setIsReviewOpen(true)}
         />

--- a/src/shared/ui/card/CardActions.tsx
+++ b/src/shared/ui/card/CardActions.tsx
@@ -1,4 +1,8 @@
+'use client';
+
 import Link from 'next/link';
+import { useState } from 'react';
+import DeleteActivityDialog from '@/features/my-page/common/ui/DeleteActivityDialog';
 import Button from '@/shared/ui/button/Button';
 import { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 
@@ -16,6 +20,41 @@ type ReservationCardActionsProps = {
 };
 
 type CardActionsProps = ManageCardActionsProps | ReservationCardActionsProps;
+
+function ManageCardActions({ activityId }: { activityId: number }) {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <Button
+          as={Link}
+          href={`/activity/${activityId}/edit`}
+          theme="secondary"
+          size="sm"
+          className="w-17 rounded-lg"
+        >
+          수정하기
+        </Button>
+        <Button
+          type="button"
+          theme="gray"
+          size="sm"
+          className="w-17 rounded-lg"
+          onClick={() => setIsDeleteOpen(true)}
+        >
+          삭제하기
+        </Button>
+      </div>
+
+      <DeleteActivityDialog
+        id={activityId}
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+      />
+    </>
+  );
+}
 
 /**
  * 체험/예약 카드 하단의 액션 버튼 컴포넌트입니다.
@@ -44,29 +83,7 @@ type CardActionsProps = ManageCardActionsProps | ReservationCardActionsProps;
 export default function CardActions(props: CardActionsProps) {
   // 내 체험 관리 버튼
   if (props.type === 'manage') {
-    return (
-      <div className="flex gap-2">
-        <Button
-          as={Link}
-          href={`/activity/${props.activityId}/edit`}
-          theme="secondary"
-          size="sm"
-          className="w-17 rounded-lg"
-        >
-          수정하기
-        </Button>
-        {/* TODO: 삭제 확인 모달 연결 필요 */}
-        <Button
-          type="button"
-          theme="gray"
-          size="sm"
-          className="w-17 rounded-lg"
-          onClick={() => alert('삭제하기 버튼 클릭')}
-        >
-          삭제하기
-        </Button>
-      </div>
-    );
+    return <ManageCardActions activityId={props.activityId} />;
   }
 
   const { status, reviewSubmitted, activityId } = props;

--- a/src/shared/ui/card/CardActions.tsx
+++ b/src/shared/ui/card/CardActions.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useState } from 'react';
 import DeleteActivityDialog from '@/features/my-page/common/ui/DeleteActivityDialog';
+import CancelReservationDialog from '@/features/reservation/reservation-list/ui/CancelReservationDialog';
 import Button from '@/shared/ui/button/Button';
 import { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 
@@ -15,6 +16,7 @@ type ReservationCardActionsProps = {
   type: 'reservation';
   status: ReservationStatus;
   reviewSubmitted?: boolean;
+  reservationId?: number;
   activityId?: number;
   onReviewClick?: () => void;
 };
@@ -56,6 +58,47 @@ function ManageCardActions({ activityId }: { activityId: number }) {
   );
 }
 
+function PendingReservationCardActions({
+  reservationId,
+  activityId,
+}: {
+  reservationId: number;
+  activityId: number;
+}) {
+  const [isCancelOpen, setIsCancelOpen] = useState(false);
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <Button
+          as={Link}
+          href={`/activity/${activityId}`}
+          theme="secondary"
+          size="sm"
+          className="w-17 rounded-lg"
+        >
+          예약 변경
+        </Button>
+        <Button
+          type="button"
+          theme="gray"
+          size="sm"
+          className="w-17 rounded-lg"
+          onClick={() => setIsCancelOpen(true)}
+        >
+          예약 취소
+        </Button>
+      </div>
+
+      <CancelReservationDialog
+        reservationId={reservationId}
+        isOpen={isCancelOpen}
+        onClose={() => setIsCancelOpen(false)}
+      />
+    </>
+  );
+}
+
 /**
  * 체험/예약 카드 하단의 액션 버튼 컴포넌트입니다.
  *
@@ -90,28 +133,9 @@ export default function CardActions(props: CardActionsProps) {
 
   // 예약 완료 시 버튼
   if (status === 'pending') {
+    if (!activityId || !props.reservationId) return null;
     return (
-      <div className="flex gap-2">
-        <Button
-          as={Link}
-          href={`/activity/${activityId}`}
-          theme="secondary"
-          size="sm"
-          className="w-17 rounded-lg"
-        >
-          예약 변경
-        </Button>
-        {/* TODO: 예약 취소 확인 모달 연결 필요 */}
-        <Button
-          type="button"
-          theme="gray"
-          size="sm"
-          className="w-17 rounded-lg"
-          onClick={() => alert('예약 취소 버튼 클릭')}
-        >
-          예약 취소
-        </Button>
-      </div>
+      <PendingReservationCardActions reservationId={props.reservationId} activityId={activityId} />
     );
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #182 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 내 체험 관리 삭제 기능 연결

카드 액션(삭제하기) → DeleteActivityDialog(ConfirmDialog)로 연결
삭제 성공 시 토스트 노출 및 목록 화면으로 이동 처리

### 체험 삭제 mutation 구현(캐시 무효화 + 낙관적 업데이트)

- useDeleteActivity에서 onMutate로 my-activities 관련 쿼리 취소 후, 무한스크롤 목록 캐시에서 해당 체험을 즉시 제거(낙관적 업데이트)
- 실패 시 onError에서 이전 캐시 스냅샷으로 롤백
- 완료 시 onSettled에서 관련 쿼리 invalidate/remove로 목록 재조회 및 정합성 확보

### 예약 내역 취소 기능 구현

- BFF PATCH /api/my-reservations/{reservationId} 호출로 상태를 canceled로 변경하는 API 래퍼 추가
- 취소 확인 모달(CancelReservationDialog)을 구현해 “예약을 취소하시겠어요?” UX 적용

### 예약 취소 mutation 구현(낙관적 업데이트)

- useCancelMyReservation에서 onMutate로 my-reservations 무한목록 쿼리 취소 후, 캐시 내 해당 예약의 status를 canceled로 즉시 업데이트
- 실패 시 onError에서 캐시 롤백
- 완료 시 onSettled에서 my-reservations invalidate로 서버 상태와 동기화

### 예약 내역 카드 액션 연결

- pending 상태의 “예약 취소” 버튼 클릭 → 취소 모달 오픈 → mutation 실행되도록 연결
- 예약 카드에서 reservationId를 전달해 정확한 예약을 취소하도록 매핑

### 에러 처리 강화

- 삭제/취소 실패 시 백엔드 메시지를 토스트로 노출하고, 401은 로그인 필요 안내 및 로그인 페이지 이동 처리

### 상세 페이지 
- 체험 상세 페이지에서 404 응답 시 notFound()로 정상 라우팅되도록 예외 처리

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 현재 체험 관리 페이지에서 나오는 500 에러는 무시해주세요
   - #230 여기서 수정할 예정입니다!
   - 새로고침하면 테스트 진행하실 수 있을 거예요!

- my_acitivites 쿼리를 쿼리키로 등록하지 않고 사용하고 있는데 #230 그것도 여기서 같이 수정할 예정입니다!