### PR TITLE
[🐛 Fix/#253] 페이지 이동 시 불필요한 알림 재요청 방지

### DIFF
--- a/src/features/notification/queries/useMyNotifications.ts
+++ b/src/features/notification/queries/useMyNotifications.ts
@@ -39,7 +39,7 @@ export const useMyNotifications = ({ size = MY_NOTIFICATIONS_PAGE_SIZE } = {}) =
     refetchInterval: MY_NOTIFICATIONS_REFETCH_INTERVAL_MS,
     refetchOnMount: false,
     refetchOnReconnect: true,
-    refetchOnWindowFocus: 'always',
+    refetchOnWindowFocus: true,
     retry: 1,
   });
 

--- a/src/features/notification/queries/useMyNotifications.ts
+++ b/src/features/notification/queries/useMyNotifications.ts
@@ -38,7 +38,7 @@ export const useMyNotifications = ({ size = MY_NOTIFICATIONS_PAGE_SIZE } = {}) =
     staleTime: MY_NOTIFICATIONS_STALE_TIME_MS,
     refetchInterval: MY_NOTIFICATIONS_REFETCH_INTERVAL_MS,
     refetchOnMount: false,
-    refetchOnReconnect: false,
+    refetchOnReconnect: true,
     refetchOnWindowFocus: 'always',
     retry: 1,
   });

--- a/src/features/notification/queries/useMyNotifications.ts
+++ b/src/features/notification/queries/useMyNotifications.ts
@@ -8,7 +8,7 @@ import { useUserStore } from '@/shared/stores/userStore';
 export const MY_NOTIFICATIONS_PAGE_SIZE = 10;
 
 export const MY_NOTIFICATIONS_STALE_TIME_MS = 1000 * 10;
-export const MY_NOTIFICATIONS_REFETCH_INTERVAL_MS = 1000 * 30;
+export const MY_NOTIFICATIONS_REFETCH_INTERVAL_MS = 1000 * 60;
 
 const EMPTY_RESPONSE: GetMyNotificationsParsedResponse = {
   cursorId: null,
@@ -37,6 +37,9 @@ export const useMyNotifications = ({ size = MY_NOTIFICATIONS_PAGE_SIZE } = {}) =
     networkMode: 'always',
     staleTime: MY_NOTIFICATIONS_STALE_TIME_MS,
     refetchInterval: MY_NOTIFICATIONS_REFETCH_INTERVAL_MS,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: 'always',
     retry: 1,
   });
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #253 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 알림 조회 쿼리 동작 방식 개선
- 60초 폴링(refetchInterval: 60000)으로 주기적 갱신
- 탭/창 포커스 시 staleTime 이후에만 갱신(refetchOnWindowFocus: true)
- 페이지 이동(마운트) 시 불필요한 재요청 방지(refetchOnMount: false)
- 네트워크 재연결 시 1회 자동 갱신(refetchOnReconnect: true)

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
