### PR TITLE
[✨ Feat/#196] Proxy 구현 및 인증 로직 정리

### DIFF
--- a/src/app/(public)/(auth)/layout.tsx
+++ b/src/app/(public)/(auth)/layout.tsx
@@ -1,4 +1,5 @@
 import AuthBranding from '@/app/(public)/(auth)/ui/AuthBranding';
+import GuestGuard from '@/features/auth/guards/GuestGuard';
 import { cn } from '@/shared/utils/cn';
 
 /**
@@ -13,7 +14,9 @@ export default function AuthLayout({
 }>) {
   return (
     <main className="flex min-h-dvh w-full items-center justify-center xl:justify-between">
-      <div className={cn('mx-auto w-full max-w-187 px-6 md:px-13.5')}>{children}</div>
+      <div className={cn('mx-auto w-full max-w-187 px-6 md:px-13.5')}>
+        <GuestGuard>{children}</GuestGuard>
+      </div>
       <div
         className={cn(
           'hidden shrink-0 transition-all xl:block',

--- a/src/app/(public)/(auth)/login/page.tsx
+++ b/src/app/(public)/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import AuthHeadline from '@/app/(public)/(auth)/ui/AuthHeadline';
@@ -26,6 +26,7 @@ import { cn } from '@/shared/utils/cn';
  */
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const setSession = useUserStore((state) => state.setSession);
   const { showToast } = useToastStore();
   const methods = useForm({
@@ -59,7 +60,10 @@ export default function LoginPage() {
 
           // 쿠키 상태 동기화를 위해 refresh 후 이동
           router.refresh();
-          router.push('/');
+          const redirect = searchParams.get('redirect');
+          const safeRedirect =
+            redirect && redirect.startsWith('/') && !redirect.startsWith('//') ? redirect : '/';
+          router.push(safeRedirect);
         }
       } catch (error) {
         if (error instanceof ApiError) {
@@ -74,7 +78,7 @@ export default function LoginPage() {
         }
       }
     },
-    [router, setError, setSession, showToast]
+    [router, searchParams, setError, setSession, showToast]
   );
 
   return (

--- a/src/features/auth/guards/GuestGuard.tsx
+++ b/src/features/auth/guards/GuestGuard.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { PropsWithChildren } from 'react';
+import { useEffect } from 'react';
+import { useShallow } from 'zustand/shallow';
+import { useUserStore } from '@/shared/stores/userStore';
+
+/**
+ * 로그인/회원가입 페이지에서 사용하는 Guest 가드입니다.
+ * - 로그인한 사용자는 접근 불가 → 홈으로 리다이렉트
+ * - persist hydration 전에는 깜빡임 방지를 위해 렌더링을 보류합니다.
+ */
+export default function GuestGuard({ children }: PropsWithChildren) {
+  const router = useRouter();
+  const { user, hasHydrated } = useUserStore(
+    useShallow((state) => ({
+      user: state.user,
+      hasHydrated: state.hasHydrated,
+    }))
+  );
+
+  useEffect(() => {
+    if (!hasHydrated) return;
+    if (!user) return;
+    router.replace('/');
+    router.refresh();
+  }, [hasHydrated, router, user]);
+
+  if (!hasHydrated) return null;
+  if (user) return null;
+  return children;
+}

--- a/src/features/auth/guards/GuestGuard.tsx
+++ b/src/features/auth/guards/GuestGuard.tsx
@@ -24,7 +24,6 @@ export default function GuestGuard({ children }: PropsWithChildren) {
     if (!hasHydrated) return;
     if (!user) return;
     router.replace('/');
-    router.refresh();
   }, [hasHydrated, router, user]);
 
   if (!hasHydrated) return null;

--- a/src/features/auth/providers/AuthSessionSync.tsx
+++ b/src/features/auth/providers/AuthSessionSync.tsx
@@ -15,6 +15,7 @@ import { useUserStore } from '@/shared/stores/userStore';
  */
 export default function AuthSessionSync() {
   const hasHydrated = useUserStore((state) => state.hasHydrated);
+  const accessTokenExpiresAt = useUserStore((state) => state.accessTokenExpiresAt);
   const setUser = useUserStore((state) => state.setUser);
   const clearSession = useUserStore((state) => state.clearSession);
   const didSyncRef = useRef(false);
@@ -25,6 +26,15 @@ export default function AuthSessionSync() {
     didSyncRef.current = true;
 
     const sync = async () => {
+      // 비로그인(또는 세션 정보 없음)이라면 불필요한 `/users/me` 호출을 하지 않습니다.
+      if (!accessTokenExpiresAt) return;
+
+      // 만료된 세션이면 서버 호출 없이 클라이언트 상태만 정리합니다.
+      if (accessTokenExpiresAt <= Date.now()) {
+        clearSession('expired');
+        return;
+      }
+
       try {
         const me = await getMe();
         if (me) setUser(me);
@@ -37,7 +47,7 @@ export default function AuthSessionSync() {
     };
 
     void sync();
-  }, [clearSession, hasHydrated, setUser]);
+  }, [accessTokenExpiresAt, clearSession, hasHydrated, setUser]);
 
   return null;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,7 +8,7 @@ const decodeBase64Url = (value: string): string => {
   const padLength = (4 - (base64.length % 4)) % 4;
   const padded = base64 + '='.repeat(padLength);
 
-  return atob(padded);
+  return new TextDecoder().decode(Uint8Array.from(atob(padded), (c) => c.charCodeAt(0)));
 };
 
 const getJwtExpiresAtMs = (token: string): number | undefined => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -51,7 +51,7 @@ export const proxy = (request: NextRequest) => {
 
   const isExpired = accessTokenExpiresAtMs !== undefined && accessTokenExpiresAtMs <= Date.now();
 
-  const isLoggedIn = Boolean(accessToken) && !isExpired;
+  const isLoggedIn = Boolean(accessToken) && accessTokenExpiresAtMs !== undefined && !isExpired;
 
   // 로그인한 사용자는 로그인/회원가입 페이지로 접근하지 못하도록 처리
   if (isLoggedIn && isAuthPath(pathname)) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -42,7 +42,7 @@ const isProtectedPath = (pathname: string) => {
   return false;
 };
 
-export function proxy(request: NextRequest) {
+export const proxy = (request: NextRequest) => {
   const pathname = normalizePathname(request.nextUrl.pathname);
   const { search } = request.nextUrl;
 
@@ -72,7 +72,7 @@ export function proxy(request: NextRequest) {
   }
 
   return NextResponse.next();
-}
+};
 
 export const config = {
   matcher: [

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,87 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ACCESS_TOKEN_COOKIE_KEY = 'accessToken';
+
+const decodeBase64Url = (value: string): string => {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padLength = (4 - (base64.length % 4)) % 4;
+  const padded = base64 + '='.repeat(padLength);
+
+  return atob(padded);
+};
+
+const getJwtExpiresAtMs = (token: string): number | undefined => {
+  const parts = token.split('.');
+  if (parts.length < 2) return undefined;
+
+  try {
+    const payloadJson = decodeBase64Url(parts[1]);
+    const payload = JSON.parse(payloadJson) as { exp?: number };
+
+    if (!payload?.exp) return undefined;
+
+    return payload.exp * 1000;
+  } catch {
+    return undefined;
+  }
+};
+
+const normalizePathname = (pathname: string): string => {
+  if (pathname === '/') return '/';
+  return pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+};
+
+const isAuthPath = (pathname: string) => pathname === '/login' || pathname === '/signup';
+
+const isProtectedPath = (pathname: string) => {
+  if (pathname.startsWith('/mypage')) return true;
+  if (pathname.startsWith('/activity/new')) return true;
+  if (/^\/activity\/[^/]+\/edit$/.test(pathname)) return true;
+
+  return false;
+};
+
+export function proxy(request: NextRequest) {
+  const pathname = normalizePathname(request.nextUrl.pathname);
+  const { search } = request.nextUrl;
+
+  const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE_KEY)?.value;
+  const accessTokenExpiresAtMs = accessToken ? getJwtExpiresAtMs(accessToken) : undefined;
+
+  const isExpired = accessTokenExpiresAtMs !== undefined && accessTokenExpiresAtMs <= Date.now();
+
+  const isLoggedIn = Boolean(accessToken) && !isExpired;
+
+  // 로그인한 사용자는 로그인/회원가입 페이지로 접근하지 못하도록 처리
+  if (isLoggedIn && isAuthPath(pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/';
+    url.searchParams.delete('redirect');
+
+    return NextResponse.redirect(url);
+  }
+
+  // 비로그인 사용자는 private 영역 접근 시 로그인 페이지로 리다이렉트
+  if (!isLoggedIn && isProtectedPath(pathname)) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = '/login';
+    loginUrl.searchParams.set('redirect', `${pathname}${search}`);
+
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/mypage/:path*',
+    '/activity/new',
+    '/activity/new/:path*',
+    '/activity/:id/edit',
+    '/activity/:id/edit/:path*',
+    '/login',
+    '/signup',
+  ],
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -37,7 +37,7 @@ const isAuthPath = (pathname: string) => pathname === '/login' || pathname === '
 const isProtectedPath = (pathname: string) => {
   if (pathname.startsWith('/mypage')) return true;
   if (pathname.startsWith('/activity/new')) return true;
-  if (/^\/activity\/[^/]+\/edit$/.test(pathname)) return true;
+  if (/^\/activity\/[^/]+\/edit(\/.*)?$/.test(pathname)) return true;
 
   return false;
 };

--- a/src/shared/apis/bff/proxy.ts
+++ b/src/shared/apis/bff/proxy.ts
@@ -1,4 +1,4 @@
-import { cookies } from 'next/headers';
+import { getAuthCookie } from '@/features/auth/utils/cookies';
 import { FetchRequestOptions, QueryParams, RequestConfig } from '@/shared/apis/base/coreFetch';
 import { serverFetch } from '@/shared/apis/base/serverFetch';
 
@@ -34,8 +34,7 @@ const request = async <T>({
   ...options
 }: RequestConfig): Promise<T | null> => {
   // 1. 쿠키에서 토큰 꺼내기
-  const cookieStore = await cookies();
-  const token = cookieStore.get('accessToken')?.value;
+  const token = await getAuthCookie('accessToken');
 
   // 2. 기존 headers + Authorization 병합
   const headers = new Headers(options.headers ?? {});


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #196 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### proxy(페이지 접근 제어-middleware)

- `src/proxy.ts`
- 사용자의 페이지 접근을 판단해서 redirect로 처리했습니다
- 보호 경로(private) 접근 시 비로그인이면 로그인으로 보내고,
- 로그인 상태면 /login, /signup 접근을 막고 홈(/)으로 보내는 방식으로 했습니다

**구현 방식**
- accessToken은 request.cookies.get('accessToken')로 읽음 (middleware 정석)
- 토큰이 있으면 JWT payload의 exp를 디코딩해 만료 여부를 판단
- isLoggedIn = accessToken 존재 && 만료 아님

- **jwt 유틸을 사용하지 않은 이유는 런타임이 다를 수 있기 때문에 따로 구현했습니다**


### 비로그인 /users/me 호출 방지

- 문제 상황
  - 비로그인 상태에서도 앱 시작 시 /users/me가 반복 호출되어 401이 발생했습니다
 - 해결 방안
   - 비로그인(세션 정보 없음)일 때 AuthSessionSync에서 /users/me 호출하지 않도록 가드를 추가했습니다


### 스크린샷 (선택)

https://github.com/user-attachments/assets/49e9db54-1708-4e25-8237-9c827a82b6d9


### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
