### PR TITLE
[♻️Refactor/#262] 메인, 체험 카드 스켈레톤 UI 변경

### DIFF
--- a/src/features/activity/common/ui/skeleton/ActivityCardSkeleton.tsx
+++ b/src/features/activity/common/ui/skeleton/ActivityCardSkeleton.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/shared/utils/cn';
 export default function ActivityCardSkeleton({ className }: { className?: string }) {
   return (
     <div className={cn(cardWrapStyles, className)}>
-      <Skeleton className="relative mb-16.5 h-44 w-full overflow-hidden rounded-xl md:mb-19 md:h-93.5 lg:h-72.5" />
+      <Skeleton className="mb-16.5 h-44 w-full rounded-xl md:mb-19 md:h-93.5 lg:h-72.5" />
       <BaseCardInfo className="absolute bottom-0 p-4 md:px-7.5 md:py-5">
         <div className="flex flex-col gap-2.5 md:gap-4.5">
           <div className="flex flex-col gap-2">

--- a/src/features/activity/common/ui/skeleton/ActivityCardSkeleton.tsx
+++ b/src/features/activity/common/ui/skeleton/ActivityCardSkeleton.tsx
@@ -1,3 +1,5 @@
+import BaseCardInfo from '@/shared/ui/card/base/BaseCardInfo';
+import { cardWrapStyles } from '@/shared/ui/card/cardStyles';
 import Skeleton from '@/shared/ui/skeleton/Skeleton';
 import { cn } from '@/shared/utils/cn';
 
@@ -11,17 +13,17 @@ import { cn } from '@/shared/utils/cn';
  */
 export default function ActivityCardSkeleton({ className }: { className?: string }) {
   return (
-    <div className={cn('rounded-[18px] border border-gray-100 p-4 md:rounded-4xl', className)}>
-      {/* 이미지 영역 */}
-      <Skeleton className="h-30 w-full rounded-xl md:h-75 lg:h-56" />
-      <div className="mt-3 mb-4 flex w-full flex-col gap-2 md:mt-3 md:mb-5">
-        {/* 제목 */}
-        <Skeleton className="h-4 w-4/5 rounded-xl md:h-5 md:w-2/3" />
-        {/* 리뷰 */}
-        <Skeleton className="h-4 w-16 rounded-xl md:h-5 md:w-1/4" />
-      </div>
-      {/* 가격 */}
-      <Skeleton className="h-4 w-20 rounded-xl md:h-5 md:w-2/5" />
+    <div className={cn(cardWrapStyles, className)}>
+      <Skeleton className="relative mb-16.5 h-44 w-full overflow-hidden rounded-xl md:mb-19 md:h-93.5 lg:h-72.5" />
+      <BaseCardInfo className="absolute bottom-0 p-4 md:px-7.5 md:py-5">
+        <div className="flex flex-col gap-2.5 md:gap-4.5">
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-4 w-4/5 rounded-xl md:h-5 md:w-2/3 lg:w-40" />
+            <Skeleton className="h-4 w-16 rounded-xl md:h-5 md:w-1/4" />
+          </div>
+          <Skeleton className="h-4 w-20 rounded-xl md:h-5 md:w-2/5" />
+        </div>
+      </BaseCardInfo>
     </div>
   );
 }

--- a/src/features/activity/main/ui/MainActivityList.tsx
+++ b/src/features/activity/main/ui/MainActivityList.tsx
@@ -42,7 +42,7 @@ export default function MainActivityList() {
       {isLoading && !isSkeletonVisible ? null : isSkeletonVisible ? (
         <>
           {/* 기본: 1개 반 노출, md: 2개 노출, lg: 8개 노출 */}
-          <div className="flex gap-4 overflow-visible md:grid md:grid-cols-2 md:gap-5 lg:grid-cols-4 lg:gap-6">
+          <div className="flex gap-4 overflow-hidden p-2 md:grid md:grid-cols-2 md:gap-5 lg:grid-cols-4 lg:gap-6">
             {Array.from({ length: 4 }).map((_, i) => (
               <ActivityCardSkeleton
                 key={i}

--- a/src/features/activity/main/ui/MainActivityList.tsx
+++ b/src/features/activity/main/ui/MainActivityList.tsx
@@ -42,17 +42,20 @@ export default function MainActivityList() {
       {isLoading && !isSkeletonVisible ? null : isSkeletonVisible ? (
         <>
           {/* 기본: 1개 반 노출, md: 2개 노출, lg: 8개 노출 */}
-          <div className="flex gap-4 overflow-hidden p-2 md:grid md:grid-cols-2 md:gap-5 lg:grid-cols-4 lg:gap-6">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <ActivityCardSkeleton
-                key={i}
-                className={cn(
-                  'w-[calc(70%-6px)] shrink-0',
-                  'md:w-auto md:shrink',
-                  i >= 2 ? 'hidden lg:block' : ''
-                )}
-              />
-            ))}
+          <div className="overflow-hidden pb-4">
+            <ul className="flex gap-4 md:gap-5 lg:gap-6">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <li
+                  key={i}
+                  className={cn(
+                    'w-[calc((100%-50px*2)/2)] min-w-50 flex-none md:w-[calc((100%-20px*1)/2)] lg:w-[calc((100%-24px*3)/4)]',
+                    i >= 3 ? 'hidden lg:block' : ''
+                  )}
+                >
+                  <ActivityCardSkeleton />
+                </li>
+              ))}
+            </ul>
           </div>
         </>
       ) : isError ? (

--- a/src/features/activity/main/ui/MainActivityList.tsx
+++ b/src/features/activity/main/ui/MainActivityList.tsx
@@ -42,7 +42,7 @@ export default function MainActivityList() {
       {isLoading && !isSkeletonVisible ? null : isSkeletonVisible ? (
         <>
           {/* 기본: 1개 반 노출, md: 2개 노출, lg: 8개 노출 */}
-          <div className="flex gap-4 overflow-hidden md:grid md:grid-cols-2 md:gap-5 lg:grid-cols-4 lg:gap-6">
+          <div className="flex gap-4 overflow-visible md:grid md:grid-cols-2 md:gap-5 lg:grid-cols-4 lg:gap-6">
             {Array.from({ length: 4 }).map((_, i) => (
               <ActivityCardSkeleton
                 key={i}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #262

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

메인, 체험 카드 스켈레톤 UI 스타일 변경했습니당

### 스크린샷 (선택)
<img width="1230" height="446" alt="스크린샷 2026-05-14 22 05 50" src="https://github.com/user-attachments/assets/feebb0eb-cdf4-407a-8528-5770e04ad0b2" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
