### PR TITLE
[♻️ Refactor/#271] 체험 등록/수정 페이지 헤더 서버 컴포넌트 분리

### DIFF
--- a/src/app/(private)/activity/[id]/edit/page.tsx
+++ b/src/app/(private)/activity/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { notFound } from 'next/navigation';
 import { activityDetailQueryOptions } from '@/features/my-page/activity-form/edit/queries/useActivityDetail';
 import ActivityEditClient from '@/features/my-page/activity-form/edit/ui/ActivityEditClient';
+import PageHeader from '@/shared/ui/page-header/PageHeader';
 import { getQueryClient } from '@/shared/utils/getQueryClient';
 
 export default async function ActivityEditPage({ params }: { params: { id: string } }) {
@@ -21,8 +22,15 @@ export default async function ActivityEditPage({ params }: { params: { id: strin
   }
 
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <ActivityEditClient activityId={activityId} />
-    </HydrationBoundary>
+    // 서버 단에서 레이아웃과 헤더를 먼저 그림
+    <div className="mx-auto w-full max-w-3xl px-4 pt-10 md:px-0 md:pt-14">
+      <div className="mb-10">
+        <PageHeader title="내 체험 수정" />
+      </div>
+
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ActivityEditClient activityId={activityId} />
+      </HydrationBoundary>
+    </div>
   );
 }

--- a/src/app/(private)/activity/[id]/edit/page.tsx
+++ b/src/app/(private)/activity/[id]/edit/page.tsx
@@ -22,16 +22,14 @@ export default async function ActivityEditPage({ params }: { params: { id: strin
   }
 
   return (
-    // 서버 단에서 레이아웃과 헤더를 먼저 그림
-    <div className="w-full pb-15.25 md:pb-9.25">
-      <div className="mx-auto w-full max-w-3xl px-4 pt-10 md:px-0 md:pt-14">
-        <div className="mb-10">
-          <PageHeader title="내 체험 수정" />
-        </div>
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <ActivityEditClient activityId={activityId} />
-        </HydrationBoundary>
+    <>
+      <div className="mb-10">
+        <PageHeader title="내 체험 수정" />
       </div>
-    </div>
+
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ActivityEditClient activityId={activityId} />
+      </HydrationBoundary>
+    </>
   );
 }

--- a/src/app/(private)/activity/[id]/edit/page.tsx
+++ b/src/app/(private)/activity/[id]/edit/page.tsx
@@ -23,14 +23,15 @@ export default async function ActivityEditPage({ params }: { params: { id: strin
 
   return (
     // 서버 단에서 레이아웃과 헤더를 먼저 그림
-    <div className="mx-auto w-full max-w-3xl px-4 pt-10 md:px-0 md:pt-14">
-      <div className="mb-10">
-        <PageHeader title="내 체험 수정" />
+    <div className="w-full pb-15.25 md:pb-9.25">
+      <div className="mx-auto w-full max-w-3xl px-4 pt-10 md:px-0 md:pt-14">
+        <div className="mb-10">
+          <PageHeader title="내 체험 수정" />
+        </div>
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <ActivityEditClient activityId={activityId} />
+        </HydrationBoundary>
       </div>
-
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <ActivityEditClient activityId={activityId} />
-      </HydrationBoundary>
     </div>
   );
 }

--- a/src/app/(private)/activity/layout.tsx
+++ b/src/app/(private)/activity/layout.tsx
@@ -1,0 +1,9 @@
+import { WithChildren } from '@/shared/types/common';
+
+export default function ActivityLayout({ children }: WithChildren) {
+  return (
+    <div className="w-full pb-15.25 md:pb-9.25">
+      <div className="mx-auto w-full max-w-3xl px-4 pt-10 md:pt-14">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(private)/activity/new/page.tsx
+++ b/src/app/(private)/activity/new/page.tsx
@@ -9,14 +9,12 @@ import PageHeader from '@/shared/ui/page-header/PageHeader';
  */
 export default function ActivityNewPage() {
   return (
-    // 서버 단에서 레이아웃과 <h1> 태그를 먼저 렌더링
-    <div className="w-full pb-15.25 md:pb-9.25">
-      <div className="mx-auto w-full max-w-3xl px-4 pt-10 md:px-0 md:pt-14">
-        <div className="mb-10">
-          <PageHeader title="내 체험 등록" />
-        </div>
-        <ActivityNewClient />
+    <>
+      <div className="mb-10">
+        <PageHeader title="내 체험 등록" />
       </div>
-    </div>
+
+      <ActivityNewClient />
+    </>
   );
 }

--- a/src/app/(private)/activity/new/page.tsx
+++ b/src/app/(private)/activity/new/page.tsx
@@ -3,6 +3,9 @@ import PageHeader from '@/shared/ui/page-header/PageHeader';
 
 /**
  * 새로운 체험을 등록하는 페이지 서버 컴포넌트입니다.
+ *
+ * @example
+ * <ActivityNewClient />
  */
 export default function ActivityNewPage() {
   return (

--- a/src/app/(private)/activity/new/page.tsx
+++ b/src/app/(private)/activity/new/page.tsx
@@ -1,22 +1,19 @@
-'use client';
-
-import ActivityFormPageShell from '@/features/my-page/activity-form/common/ui/ActivityFormPageShell';
-import { useActivitySubmit } from '@/features/my-page/activity-form/new/hooks/useActivitySubmit';
+import ActivityNewClient from '@/features/my-page/activity-form/new/ui/ActivityNewClient';
+import PageHeader from '@/shared/ui/page-header/PageHeader';
 
 /**
- * 새로운 체험을 등록하는 페이지 컴포넌트입니다.
+ * 새로운 체험을 등록하는 페이지 서버 컴포넌트입니다.
  */
 export default function ActivityNewPage() {
-  const { submitActivity, isPending } = useActivitySubmit();
-
   return (
-    <ActivityFormPageShell
-      title="내 체험 등록"
-      mode="create"
-      onSubmitForm={submitActivity}
-      isPending={isPending}
-      resetToastMessage="내용이 초기화되었습니다."
-      confirmText="계속 작성하기"
-    />
+    // 서버 단에서 레이아웃과 <h1> 태그를 먼저 렌더링
+    <div className="w-full pb-15.25 md:pb-9.25">
+      <div className="mx-auto w-full max-w-3xl px-4 pt-10 md:px-0 md:pt-14">
+        <div className="mb-10">
+          <PageHeader title="내 체험 등록" />
+        </div>
+        <ActivityNewClient />
+      </div>
+    </div>
   );
 }

--- a/src/features/my-page/activity-form/common/ui/ActivityFormPageShell.tsx
+++ b/src/features/my-page/activity-form/common/ui/ActivityFormPageShell.tsx
@@ -22,6 +22,17 @@ export type ActivityFormPageShellProps = {
   containerClassName?: string;
 };
 
+/**
+ * 체험 등록 및 수정 페이지의 공통 레이아웃과 비즈니스 로직을 관리하는 쉘 컴포넌트입니다.
+ *
+ * @example
+ * <ActivityFormPageShell
+ *   mode="create"
+ *   onSubmitForm={handleSubmit}
+ *   resetToastMessage="초기화되었습니다."
+ *   confirmText="확인"
+ * />
+ */
 export default function ActivityFormPageShell({
   mode,
   initialData,

--- a/src/features/my-page/activity-form/common/ui/ActivityFormPageShell.tsx
+++ b/src/features/my-page/activity-form/common/ui/ActivityFormPageShell.tsx
@@ -8,11 +8,9 @@ import LeaveConfirmDialog from '@/features/my-page/activity-form/common/ui/Leave
 import ResetConfirmDialog from '@/features/my-page/activity-form/common/ui/ResetConfirmDialog';
 import type { ActivityFormValues } from '@/features/my-page/activity-form/common/utils/schema';
 import { usePreventGoBack } from '@/shared/hooks/usePreventGoBack';
-import PageHeader from '@/shared/ui/page-header/PageHeader';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
 export type ActivityFormPageShellProps = {
-  title: string;
   mode: 'create' | 'edit';
   initialData?: ActivityInitialData;
   onSubmitForm: (data: ActivityFormValues) => void;
@@ -25,7 +23,6 @@ export type ActivityFormPageShellProps = {
 };
 
 export default function ActivityFormPageShell({
-  title,
   mode,
   initialData,
   onSubmitForm,
@@ -33,8 +30,8 @@ export default function ActivityFormPageShell({
   isErrorData = false,
   resetToastMessage,
   confirmText,
-  mainClassName = 'w-full pb-15.25 md:pb-9.25',
-  containerClassName = 'mx-auto w-full max-w-3xl px-4 pt-10 md:px-0 md:pt-14',
+  mainClassName = '', // 여백은 부모에서 잡을 거라 기본값 초기화
+  containerClassName = 'w-full', // 가로폭만 다 차지하도록 설정
 }: ActivityFormPageShellProps) {
   const { showToast } = useToastStore();
 
@@ -69,10 +66,6 @@ export default function ActivityFormPageShell({
   return (
     <div className={mainClassName}>
       <div className={containerClassName}>
-        <div className="mb-10">
-          <PageHeader title={title} />
-        </div>
-
         {/* 수정 모드일 때는 데이터가 있어야만 렌더링, 등록 모드는 항상 렌더링 */}
         {(mode === 'create' || initialData) && (
           <ActivityForm

--- a/src/features/my-page/activity-form/edit/ui/ActivityEditClient.tsx
+++ b/src/features/my-page/activity-form/edit/ui/ActivityEditClient.tsx
@@ -54,7 +54,6 @@ export default function ActivityEditClient({ activityId }: ActivityEditClientPro
 
   return (
     <ActivityFormPageShell
-      title="내 체험 수정"
       mode="edit"
       initialData={initialData}
       onSubmitForm={submitActivityEdit}
@@ -62,7 +61,7 @@ export default function ActivityEditClient({ activityId }: ActivityEditClientPro
       resetToastMessage="수정 전 상태로 초기화되었습니다."
       confirmText="계속 수정하기"
       mainClassName=""
-      containerClassName="mx-auto w-full max-w-3xl px-4 pt-10 md:px-0 md:pt-14"
+      containerClassName="w-full" // 여백은 부모에서 잡을 거라 가로폭만 다 차지하도록 설정
     />
   );
 }

--- a/src/features/my-page/activity-form/edit/ui/ActivityEditClient.tsx
+++ b/src/features/my-page/activity-form/edit/ui/ActivityEditClient.tsx
@@ -60,8 +60,6 @@ export default function ActivityEditClient({ activityId }: ActivityEditClientPro
       isPending={isPending}
       resetToastMessage="수정 전 상태로 초기화되었습니다."
       confirmText="계속 수정하기"
-      mainClassName=""
-      containerClassName="w-full" // 여백은 부모에서 잡을 거라 가로폭만 다 차지하도록 설정
     />
   );
 }

--- a/src/features/my-page/activity-form/new/ui/ActivityNewClient.tsx
+++ b/src/features/my-page/activity-form/new/ui/ActivityNewClient.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import ActivityFormPageShell from '@/features/my-page/activity-form/common/ui/ActivityFormPageShell';
+import { useActivitySubmit } from '@/features/my-page/activity-form/new/hooks/useActivitySubmit';
+
+/**
+ * 새로운 체험을 등록하는 컴포넌트입니다.
+ */
+export default function ActivityNewClient() {
+  const { submitActivity, isPending } = useActivitySubmit();
+
+  return (
+    <ActivityFormPageShell
+      mode="create"
+      onSubmitForm={submitActivity}
+      isPending={isPending}
+      resetToastMessage="내용이 초기화되었습니다."
+      confirmText="계속 작성하기"
+      mainClassName=""
+      containerClassName="w-full"
+    />
+  );
+}

--- a/src/features/my-page/activity-form/new/ui/ActivityNewClient.tsx
+++ b/src/features/my-page/activity-form/new/ui/ActivityNewClient.tsx
@@ -16,8 +16,6 @@ export default function ActivityNewClient() {
       isPending={isPending}
       resetToastMessage="내용이 초기화되었습니다."
       confirmText="계속 작성하기"
-      mainClassName=""
-      containerClassName="w-full"
     />
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #271 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 공통 쉘 컴포넌트 리팩토링
`PageHeader` 렌더링 로직 및 불필요해진 `title` prop 제거
- 서버/클라이언트 컴포넌트 분리
최상단에서 레이아웃을 제어하고  `PageHeader` 렌더링

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
