### PR TITLE
[♻️ Refactor/#274] 예약내역/체험 관리 page-header 서버 컴포넌트로 변경

### DIFF
--- a/src/app/(private)/mypage/activity/page.tsx
+++ b/src/app/(private)/mypage/activity/page.tsx
@@ -4,7 +4,7 @@ import PageHeader from '@/shared/ui/page-header/PageHeader';
 
 export default function MyActivityPage() {
   return (
-    <div className="mb-10 flex w-full flex-col gap-4 md:w-119 md:gap-7.5 lg:w-160">
+    <div className="mypage-content">
       {/* Page Header */}
       <div className="flex items-start justify-between">
         <PageHeader

--- a/src/app/(private)/mypage/activity/page.tsx
+++ b/src/app/(private)/mypage/activity/page.tsx
@@ -1,13 +1,16 @@
 import MyActivityCreateButton from '@/features/my-page/my-activity/ui/MyActivityCreateButton';
 import MyActivityList from '@/features/my-page/my-activity/ui/MyActivityList';
-import MyActivityPageHeader from '@/features/my-page/my-activity/ui/MyActivityPageHeader';
+import PageHeader from '@/shared/ui/page-header/PageHeader';
 
 export default function MyActivityPage() {
   return (
     <div className="mb-10 flex w-full flex-col gap-4 md:w-119 md:gap-7.5 lg:w-160">
       {/* Page Header */}
       <div className="flex items-start justify-between">
-        <MyActivityPageHeader />
+        <PageHeader
+          title="내 체험 관리"
+          description="체험을 등록하거나 수정 및 삭제가 가능합니다."
+        />
         <MyActivityCreateButton />
       </div>
 

--- a/src/app/(private)/mypage/reservation-list/page.tsx
+++ b/src/app/(private)/mypage/reservation-list/page.tsx
@@ -1,9 +1,11 @@
 import { Suspense } from 'react';
 import ReservationListView from '@/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView';
+import PageHeader from '@/shared/ui/page-header/PageHeader';
 
 export default function ReservationListPage() {
   return (
     <div className="mb-10 flex w-full flex-col gap-4 md:w-119 md:gap-7.5 lg:w-160">
+      <PageHeader title="예약내역" description="예약내역 변경 및 취소할 수 있습니다." />
       <Suspense>
         <ReservationListView />
       </Suspense>

--- a/src/app/(private)/mypage/reservation-list/page.tsx
+++ b/src/app/(private)/mypage/reservation-list/page.tsx
@@ -4,7 +4,7 @@ import PageHeader from '@/shared/ui/page-header/PageHeader';
 
 export default function ReservationListPage() {
   return (
-    <div className="mb-10 flex w-full flex-col gap-4 md:w-119 md:gap-7.5 lg:w-160">
+    <div className="mypage-content">
       <PageHeader title="예약내역" description="예약내역 변경 및 취소할 수 있습니다." />
       <Suspense>
         <ReservationListView />

--- a/src/features/my-page/common/ui/sidebar/MyPageSidebar.tsx
+++ b/src/features/my-page/common/ui/sidebar/MyPageSidebar.tsx
@@ -47,7 +47,7 @@ export default function MyPageSidebar() {
         </div>
         <MyPageNav />
       </aside>
-      <div className="sticky top-12 layer-header mb-6 bg-white pt-3 md:hidden">
+      <div className="sticky top-12 layer-base mb-6 bg-white pt-3 md:hidden">
         <TabNav tabs={MYPAGE_TABS} tabClassName="flex-1" />
       </div>
     </>

--- a/src/features/my-page/my-activity/ui/MyActivityPageHeader.tsx
+++ b/src/features/my-page/my-activity/ui/MyActivityPageHeader.tsx
@@ -1,9 +1,0 @@
-'use client';
-
-import PageHeader from '@/shared/ui/page-header/PageHeader';
-
-export default function MyActivityPageHeader() {
-  return (
-    <PageHeader title="내 체험 관리" description="체험을 등록하거나 수정 및 삭제가 가능합니다." />
-  );
-}

--- a/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
+++ b/src/features/reservation/reservation-list/ui/my-reservation-list/ReservationListView.tsx
@@ -14,7 +14,6 @@ import type { MyReservation, MyReservationStatus } from '@/features/reservation/
 import { useInfiniteScroll } from '@/shared/hooks/useInfiniteScroll';
 import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
 import InfiniteScrollSentinel from '@/shared/ui/infinite-scroll/InfiniteScrollSentinel';
-import PageHeader from '@/shared/ui/page-header/PageHeader';
 import type { ReservationStatus } from '@/shared/ui/state-badge/StateBadge';
 
 const RESERVATION_LIST_PATH = '/mypage/reservation-list';
@@ -91,8 +90,6 @@ export default function ReservationListView() {
   return (
     <div className="flex flex-col gap-7.5 pb-17.5">
       <div className="flex flex-col gap-3.5">
-        <PageHeader title="예약내역" description="예약내역 변경 및 취소할 수 있습니다." />
-
         <StatusFilter selectedStatus={selectedStatus} onSelectStatus={handleSelectStatus} />
       </div>
 

--- a/src/shared/styles/layout.css
+++ b/src/shared/styles/layout.css
@@ -1,3 +1,7 @@
 @utility shell-inner {
   @apply mx-auto flex h-full w-full max-w-380 items-center justify-between px-6 md:px-7.5 xl:px-50;
 }
+
+@utility mypage-content {
+  @apply mb-10 flex w-full flex-col gap-4 md:gap-7.5 lg:w-160;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #274 
## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 예약내역/내 체험 관리 페이지의 PageHeader를 페이지 파일로 이동하여 서버 컴포넌트에서 렌더링되도록 변경
- 예약내역/내 체험 관리 페이지 공통 레이아웃 적용으로 리팩토링
- 마이페이지 모바일에서 탭바 z-index로 인해 헤더의 드롭다운이 탭바 아래로 내려가는 문제 수정

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
