### PR TITLE
[♻️ Refactor/#276] 알림 캐시 사용자 분리 및 토스트 UI 개선

### DIFF
--- a/src/features/notification/mutations/useDeleteAllMyNotifications.ts
+++ b/src/features/notification/mutations/useDeleteAllMyNotifications.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { deleteMyNotification } from '@/features/notification/apis';
 import type { GetMyNotificationsParsedResponse } from '@/features/notification/types';
 import { QUERY_KEYS } from '@/shared/constants/queryKey';
+import { useUserStore } from '@/shared/stores/userStore';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
 type UseDeleteAllMyNotificationsParams = {
@@ -16,12 +17,14 @@ type UseDeleteAllMyNotificationsParams = {
 export const useDeleteAllMyNotifications = () => {
   const queryClient = useQueryClient();
   const { showToast } = useToastStore();
+  const userId = useUserStore((s) => s.user?.id);
 
   const deleteAll = useCallback(
     async ({ ids, onStart }: UseDeleteAllMyNotificationsParams) => {
       if (ids.length === 0) return;
+      if (!userId) return;
 
-      const myNotificationsQueryKey = QUERY_KEYS.MY_NOTIFICATIONS_BASE();
+      const myNotificationsQueryKey = QUERY_KEYS.MY_NOTIFICATIONS_BASE(userId);
 
       onStart?.();
 
@@ -74,7 +77,7 @@ export const useDeleteAllMyNotifications = () => {
         queryKey: myNotificationsQueryKey,
       });
     },
-    [queryClient, showToast]
+    [queryClient, showToast, userId]
   );
 
   return { deleteAll };

--- a/src/features/notification/mutations/useDeleteMyNotificationMutation.ts
+++ b/src/features/notification/mutations/useDeleteMyNotificationMutation.ts
@@ -2,23 +2,29 @@ import type { InfiniteData } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteMyNotification } from '@/features/notification/apis';
 import type { GetMyNotificationsParsedResponse } from '@/features/notification/types';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
+import { useUserStore } from '@/shared/stores/userStore';
 
 export const useDeleteMyNotificationMutation = () => {
   const queryClient = useQueryClient();
+  const userId = useUserStore((s) => s.user?.id);
+  const myNotificationsQueryKey = QUERY_KEYS.MY_NOTIFICATIONS_BASE(userId);
 
   return useMutation({
     mutationFn: deleteMyNotification,
     onMutate: async (notificationId) => {
-      await queryClient.cancelQueries({ queryKey: ['my-notifications'] });
+      if (!userId) return;
+
+      await queryClient.cancelQueries({ queryKey: myNotificationsQueryKey });
 
       const previousQueries = queryClient.getQueriesData<
         InfiniteData<GetMyNotificationsParsedResponse>
       >({
-        queryKey: ['my-notifications'],
+        queryKey: myNotificationsQueryKey,
       });
 
       queryClient.setQueriesData<InfiniteData<GetMyNotificationsParsedResponse>>(
-        { queryKey: ['my-notifications'] },
+        { queryKey: myNotificationsQueryKey },
         (old) => {
           if (!old) return old;
           return {
@@ -42,7 +48,8 @@ export const useDeleteMyNotificationMutation = () => {
     // onMutate에서 이미 낙관적 업데이트를 수행합니다.
     onSuccess: () => {},
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: ['my-notifications'] });
+      if (!userId) return;
+      void queryClient.invalidateQueries({ queryKey: myNotificationsQueryKey });
     },
   });
 };

--- a/src/features/notification/mutations/useMarkMyNotificationsSeenMutation.ts
+++ b/src/features/notification/mutations/useMarkMyNotificationsSeenMutation.ts
@@ -2,16 +2,20 @@ import type { InfiniteData } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { markMyNotificationsSeen } from '@/features/notification/apis';
 import type { GetMyNotificationsParsedResponse } from '@/features/notification/types';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
+import { useUserStore } from '@/shared/stores/userStore';
 
 export const useMarkMyNotificationsSeenMutation = () => {
   const queryClient = useQueryClient();
+  const userId = useUserStore((s) => s.user?.id);
 
   return useMutation({
     mutationFn: markMyNotificationsSeen,
     onSuccess: () => {
+      if (!userId) return;
       const now = Date.now();
       queryClient.setQueriesData<InfiniteData<GetMyNotificationsParsedResponse>>(
-        { queryKey: ['my-notifications'] },
+        { queryKey: QUERY_KEYS.MY_NOTIFICATIONS_BASE(userId) },
         (old) => {
           if (!old) return old;
           return {

--- a/src/features/notification/queries/useMyNotifications.ts
+++ b/src/features/notification/queries/useMyNotifications.ts
@@ -28,7 +28,7 @@ export const useMyNotifications = ({ size = MY_NOTIFICATIONS_PAGE_SIZE } = {}) =
     QueryKey,
     number | undefined
   >({
-    queryKey: QUERY_KEYS.MY_NOTIFICATIONS(size),
+    queryKey: QUERY_KEYS.MY_NOTIFICATIONS(userId, size),
     enabled: !!userId,
     initialPageParam: undefined,
     queryFn: async ({ pageParam }) =>

--- a/src/features/notification/ui/NotificationButton.tsx
+++ b/src/features/notification/ui/NotificationButton.tsx
@@ -53,7 +53,7 @@ export default function NotificationButton({ theme = 'light' }: NotificationButt
     hasNew,
     lastSeenAtMs,
     markSeen: () => markSeenMutation.mutateAsync(),
-    onEmpty: () => showToast('warning', '알림이 없습니다.'),
+    onEmpty: () => showToast('info', '알림이 없습니다.'),
   });
 
   useOutsideClick(notificationRef, dropdown.close, dropdown.isOpen);

--- a/src/shared/constants/queryKey.ts
+++ b/src/shared/constants/queryKey.ts
@@ -23,11 +23,11 @@ export const QUERY_KEYS = {
   MY_RESERVATIONS: (status?: string, size?: number) =>
     ['my-reservations', status ?? 'all', size ?? 'default'] as const,
   /** 내 알림 조회 - prefix */
-  MY_NOTIFICATIONS_BASE: () => ['my-notifications'] as const,
+  MY_NOTIFICATIONS_BASE: (userId?: number) => ['my-notifications', userId ?? 'anonymous'] as const,
 
   /** 내 알림 조회 */
-  MY_NOTIFICATIONS: (size?: number) =>
-    [...QUERY_KEYS.MY_NOTIFICATIONS_BASE(), size ?? 'default'] as const,
+  MY_NOTIFICATIONS: (userId?: number, size?: number) =>
+    [...QUERY_KEYS.MY_NOTIFICATIONS_BASE(userId), size ?? 'default'] as const,
 
   /** 내 체험 목록 조회 - prefix */
   MY_ACTIVITIES_BASE: () => ['my-activities'] as const,

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -48,7 +48,7 @@ export default function Toast({ type, message, onClose }: ToastProps) {
       aria-live="polite"
       onTransitionEnd={isClosing ? onClose : undefined}
       className={cn(
-        'flex w-full max-w-[min(420px,calc(100vw-2rem))] items-center rounded-full bg-gray-700 px-4 py-3 transition-opacity duration-300 md:px-7',
+        'flex w-full items-center rounded-full bg-gray-700 px-4 py-3 transition-opacity duration-300 md:px-7',
         isClosing ? 'opacity-0' : 'opacity-100'
       )}
     >

--- a/src/shared/ui/toast/ToastContainer.tsx
+++ b/src/shared/ui/toast/ToastContainer.tsx
@@ -11,7 +11,7 @@ export default function ToastContainer() {
 
   return (
     <div className="fixed right-0 bottom-10 left-0 layer-toast flex justify-center px-4 md:justify-end md:px-10">
-      <div className="flex flex-col gap-2 md:w-auto md:items-end">
+      <div className="flex w-full max-w-[min(420px,calc(100vw-2rem))] flex-col gap-2 md:items-end">
         {toasts.map((toast) => (
           <Toast
             key={toast.id}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #276

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 알림이 없는 경우 표시되던 토스트 타입을 warning에서 info로 변경했습니다

- 여러 개의 토스트가 동시에 표시될 때, 긴 토스트가 사라지며 컨테이너 너비가 줄어들어 발생하던 레이아웃 시프트를 수정했습니다

- 토스트 스택(컨테이너)에서 너비/최대 너비를 고정하도록 변경해, 토스트 길이에 따라 너비가 흔들리지 않도록 개선했습니다

- 알림 조회/뮤테이션의 React Query queryKey에 userId를 포함해 사용자별 캐시가 분리되도록 수정했습니다



### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
