### PR TITLE
[♻️ Refactor/#290] ActivitiesPageHeader 서버 컴포넌트로 전환

### DIFF
--- a/src/features/activity/activities/ui/ActivitiesPageHeader.tsx
+++ b/src/features/activity/activities/ui/ActivitiesPageHeader.tsx
@@ -1,8 +1,5 @@
-'use client';
-
-import { useAllActivityList } from '@/features/activity/activities/hooks/useAllActivityList';
-import SortSelectDropdown from '@/features/activity/activities/ui/SortSelectDropdown';
-import CategoryFilter from '@/features/activity/main/ui/category-filter/CategoryFilter';
+import ActivityHeaderActionsCategorySort from '@/features/activity/activities/ui/ActivityHeaderActionsCategorySort';
+import { ActivityHeaderActionsSearchSort } from '@/features/activity/activities/ui/ActivityHeaderActionsSearchSort';
 import PageHeader from '@/shared/ui/page-header/PageHeader';
 import SearchInput from '@/shared/ui/search-input/SearchInput';
 
@@ -20,8 +17,6 @@ import SearchInput from '@/shared/ui/search-input/SearchInput';
  * - 하단: CategoryFilter + SortSelectDropdown
  */
 export default function ActivitiesPageHeader() {
-  const { category, sort, handleChangeCategory, handleChangeSort } = useAllActivityList();
-
   return (
     <div className="flex flex-col gap-3 sm:gap-9">
       {/* SearchInput — 모바일에서만 상단 full width */}
@@ -34,22 +29,12 @@ export default function ActivitiesPageHeader() {
         <div className="grow">
           <PageHeader title="체험활동" description="체험을 탐색할 수 있습니다" />
         </div>
-        <div className="hidden sm:block">
-          <SearchInput className="h-14! rounded-2xl! px-4! typo-14-medium! shadow-none sm:min-w-79.25" />
-        </div>
-        <div className="sm:hidden">
-          <SortSelectDropdown sortValue={sort} onChangeSortValue={handleChangeSort} />
-        </div>
+        <ActivityHeaderActionsSearchSort />
       </div>
 
       {/* CategoryFilter + (데스크탑: SortSelectDropdown) */}
       <div className="flex items-center">
-        <div className="grow">
-          <CategoryFilter selectedCategory={category} onChangeCategory={handleChangeCategory} />
-        </div>
-        <div className="ml-5 hidden min-w-40 sm:block">
-          <SortSelectDropdown sortValue={sort} onChangeSortValue={handleChangeSort} />
-        </div>
+        <ActivityHeaderActionsCategorySort />
       </div>
     </div>
   );

--- a/src/features/activity/activities/ui/ActivitiesPageHeader.tsx
+++ b/src/features/activity/activities/ui/ActivitiesPageHeader.tsx
@@ -1,5 +1,5 @@
 import ActivityHeaderActionsCategorySort from '@/features/activity/activities/ui/ActivityHeaderActionsCategorySort';
-import { ActivityHeaderActionsSearchSort } from '@/features/activity/activities/ui/ActivityHeaderActionsSearchSort';
+import ActivityHeaderActionsSearchSort from '@/features/activity/activities/ui/ActivityHeaderActionsSearchSort';
 import PageHeader from '@/shared/ui/page-header/PageHeader';
 import SearchInput from '@/shared/ui/search-input/SearchInput';
 

--- a/src/features/activity/activities/ui/ActivityHeaderActionsCategorySort.tsx
+++ b/src/features/activity/activities/ui/ActivityHeaderActionsCategorySort.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { useAllActivityList } from '@/features/activity/activities/hooks/useAllActivityList';
+import SortSelectDropdown from '@/features/activity/activities/ui/SortSelectDropdown';
+import CategoryFilter from '@/features/activity/main/ui/category-filter/CategoryFilter';
+
+export default function ActivityHeaderActionsCategorySort() {
+  const { category, sort, handleChangeCategory, handleChangeSort } = useAllActivityList();
+  return (
+    <>
+      <div className="grow">
+        <CategoryFilter selectedCategory={category} onChangeCategory={handleChangeCategory} />
+      </div>
+      <div className="ml-5 hidden min-w-40 sm:block">
+        <SortSelectDropdown sortValue={sort} onChangeSortValue={handleChangeSort} />
+      </div>
+    </>
+  );
+}

--- a/src/features/activity/activities/ui/ActivityHeaderActionsSearchSort.tsx
+++ b/src/features/activity/activities/ui/ActivityHeaderActionsSearchSort.tsx
@@ -3,7 +3,7 @@ import { useAllActivityList } from '@/features/activity/activities/hooks/useAllA
 import SortSelectDropdown from '@/features/activity/activities/ui/SortSelectDropdown';
 import SearchInput from '@/shared/ui/search-input/SearchInput';
 
-export function ActivityHeaderActionsSearchSort() {
+export default function ActivityHeaderActionsSearchSort() {
   const { sort, handleChangeSort } = useAllActivityList();
   return (
     <>

--- a/src/features/activity/activities/ui/ActivityHeaderActionsSearchSort.tsx
+++ b/src/features/activity/activities/ui/ActivityHeaderActionsSearchSort.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { useAllActivityList } from '@/features/activity/activities/hooks/useAllActivityList';
+import SortSelectDropdown from '@/features/activity/activities/ui/SortSelectDropdown';
+import SearchInput from '@/shared/ui/search-input/SearchInput';
+
+export function ActivityHeaderActionsSearchSort() {
+  const { sort, handleChangeSort } = useAllActivityList();
+  return (
+    <>
+      <div className="hidden sm:block">
+        <SearchInput className="h-14! rounded-2xl! px-4! typo-14-medium! shadow-none sm:min-w-79.25" />
+      </div>
+      <div className="sm:hidden">
+        <SortSelectDropdown sortValue={sort} onChangeSortValue={handleChangeSort} />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #290

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

클라이언트 훅이 사용되는 컴포넌트를 따로 분리(`SearchInput + SortSelectDropdown`, `CategoryFilter + SortSelectDropdown` )하고 ActivitiesPageHeader를 서버 컴포넌트로 전환했습니다!

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
