### PR TITLE
[🚨QA/#296] 체험 상세 페이지 모바일/태블릿 푸터 완전 가림 처리

### DIFF
--- a/src/features/reservation/activity-panel/ui/ReservationBar.tsx
+++ b/src/features/reservation/activity-panel/ui/ReservationBar.tsx
@@ -99,8 +99,8 @@ export default function ReservationBar({
 
   return (
     <div className="fixed right-0 bottom-0 left-0 layer-header lg:hidden">
-      <div className="flex flex-col gap-2 border-t border-gray-100 bg-white px-4 py-3 pb-8">
-        <div className="my-3.5">
+      <div className="flex flex-col gap-2 border-t border-gray-100 bg-white px-4 pb-8">
+        <div className="my-5">
           <TotalPrice totalPrice={price} headCount={1} />
         </div>
         <Button

--- a/src/features/reservation/activity-panel/ui/ReservationBar.tsx
+++ b/src/features/reservation/activity-panel/ui/ReservationBar.tsx
@@ -99,8 +99,10 @@ export default function ReservationBar({
 
   return (
     <div className="fixed right-0 bottom-0 left-0 layer-header lg:hidden">
-      <div className="flex flex-col gap-2 border-t border-gray-100 bg-white px-4 py-3">
-        <TotalPrice totalPrice={price} headCount={1} />
+      <div className="flex flex-col gap-2 border-t border-gray-100 bg-white px-4 py-3 pb-8">
+        <div className="my-3.5">
+          <TotalPrice totalPrice={price} headCount={1} />
+        </div>
         <Button
           theme="primary"
           size="md"


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #296 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

모바일/태블릿 환경에서 하단 고정 예약 바로 인해 푸터가 일부 가려지는 문제를 수정했습니다.
* 하단 바 내부의 패딩이나 마진을 추가해 푸터가 완전히 가려짐.

### 스크린샷 (선택)
<img width="600" height="700" alt="image" src="https://github.com/user-attachments/assets/71311723-97fb-4a59-893b-7b8280a6906d" />
<img width="425" height="876" alt="image" src="https://github.com/user-attachments/assets/b7d775ad-eec1-46dc-b998-bc425f936e13" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
