### PR TITLE
 [🚨QA/#307] 로그인 유효성 검사 에러 메시지 개선

### DIFF
--- a/src/features/auth/ui/LoginClient.tsx
+++ b/src/features/auth/ui/LoginClient.tsx
@@ -70,7 +70,7 @@ export default function LoginClient() {
         }
       } catch (error) {
         if (error instanceof ApiError) {
-          // 404는 서버 메시지, 400은 고정 메시지 사용
+          // 404는 서버 메시지, 그 외 에러는 고정 메시지 사용
           const message =
             error.status === 404
               ? error.message.replace(/\.$/, '') // 마지막 온점 제거

--- a/src/features/auth/ui/LoginClient.tsx
+++ b/src/features/auth/ui/LoginClient.tsx
@@ -18,6 +18,7 @@ import PasswordInput from '@/shared/ui/input/PasswordInput';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 import { cn } from '@/shared/utils/cn';
 
+const AUTH_CLIENT_MESSAGE = '이메일 또는 비밀번호를 확인해 주세요';
 /**
  * 이메일과 비밀번호를 통한 인증을 처리합니다.
  * 성공 시 유저 정보를 Zustand 스토어에 저장하고 메인 페이지로 이동합니다.
@@ -74,7 +75,7 @@ export default function LoginClient() {
           const message =
             error.status === 404
               ? error.message.replace(/\.$/, '') // 마지막 온점 제거
-              : '이메일 또는 비밀번호를 확인해 주세요';
+              : AUTH_CLIENT_MESSAGE;
 
           setError('root', {
             type: 'server',

--- a/src/features/auth/ui/LoginClient.tsx
+++ b/src/features/auth/ui/LoginClient.tsx
@@ -70,10 +70,14 @@ export default function LoginClient() {
         }
       } catch (error) {
         if (error instanceof ApiError) {
-          // 서버에서 내려온 에러 (401, 400 등)
+          const message =
+            error.status === 404
+              ? error.message.replace(/\.$/, '') // 마지막 온점 제거
+              : '이메일 또는 비밀번호를 확인해 주세요';
+
           setError('root', {
             type: 'server',
-            message: error.message,
+            message,
           });
         } else {
           // 네트워크 에러 등

--- a/src/features/auth/ui/LoginClient.tsx
+++ b/src/features/auth/ui/LoginClient.tsx
@@ -70,6 +70,7 @@ export default function LoginClient() {
         }
       } catch (error) {
         if (error instanceof ApiError) {
+          // 404는 서버 메시지, 400은 고정 메시지 사용
           const message =
             error.status === 404
               ? error.message.replace(/\.$/, '') // 마지막 온점 제거

--- a/src/features/auth/ui/LoginClient.tsx
+++ b/src/features/auth/ui/LoginClient.tsx
@@ -17,6 +17,7 @@ import FormInput from '@/shared/ui/form/FormInput';
 import PasswordInput from '@/shared/ui/input/PasswordInput';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 import { cn } from '@/shared/utils/cn';
+import { removeDotSuffix } from '@/shared/utils/stringFormat';
 
 const AUTH_CLIENT_MESSAGE = '이메일 또는 비밀번호를 확인해 주세요';
 /**
@@ -74,7 +75,7 @@ export default function LoginClient() {
           // 404는 서버 메시지, 그 외 에러는 고정 메시지 사용
           const message =
             error.status === 404
-              ? error.message.replace(/\.$/, '') // 마지막 온점 제거
+              ? removeDotSuffix(error.message) // 마지막 온점 제거
               : AUTH_CLIENT_MESSAGE;
 
           setError('root', {

--- a/src/features/auth/ui/LoginClient.tsx
+++ b/src/features/auth/ui/LoginClient.tsx
@@ -88,7 +88,7 @@ export default function LoginClient() {
     <>
       <div className="mt-17 md:mt-22">
         <AuthForm onSubmit={handleSubmit(handleLogin)}>
-          <FormField label="이메일">
+          <FormField label="이메일" errorMessage={errors.email?.message}>
             <FormInput
               type="email"
               name="email"
@@ -97,7 +97,7 @@ export default function LoginClient() {
             />
           </FormField>
 
-          <FormField label="비밀번호">
+          <FormField label="비밀번호" errorMessage={errors.password?.message}>
             <PasswordInput
               name="password"
               control={control}

--- a/src/features/auth/ui/LoginClient.tsx
+++ b/src/features/auth/ui/LoginClient.tsx
@@ -74,9 +74,7 @@ export default function LoginClient() {
         if (error instanceof ApiError) {
           // 404는 서버 메시지, 그 외 에러는 고정 메시지 사용
           const message =
-            error.status === 404
-              ? removeDotSuffix(error.message) // 마지막 온점 제거
-              : AUTH_CLIENT_MESSAGE;
+            error.status === 404 ? removeDotSuffix(error.message) : AUTH_CLIENT_MESSAGE;
 
           setError('root', {
             type: 'server',

--- a/src/features/auth/ui/SignupClient.tsx
+++ b/src/features/auth/ui/SignupClient.tsx
@@ -63,7 +63,7 @@ export default function SignupClient() {
         if (error instanceof ApiError) {
           setError('root', {
             type: 'server',
-            message: removeDotSuffix(error.message), // 마지막 온점 제거
+            message: removeDotSuffix(error.message),
           });
         } else {
           // 네트워크 에러 등

--- a/src/features/auth/ui/SignupClient.tsx
+++ b/src/features/auth/ui/SignupClient.tsx
@@ -60,10 +60,9 @@ export default function SignupClient() {
         router.push('/login');
       } catch (error) {
         if (error instanceof ApiError) {
-          // 서버에서 내려온 에러 (409 이메일 중복 등)
           setError('root', {
             type: 'server',
-            message: error.message,
+            message: error.message.replace(/\.$/, ''), // 마지막 온점 제거
           });
         } else {
           // 네트워크 에러 등

--- a/src/features/auth/ui/SignupClient.tsx
+++ b/src/features/auth/ui/SignupClient.tsx
@@ -15,6 +15,7 @@ import FormField from '@/shared/ui/form/FormField';
 import FormInput from '@/shared/ui/form/FormInput';
 import PasswordInput from '@/shared/ui/input/PasswordInput';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
+import { removeDotSuffix } from '@/shared/utils/stringFormat';
 
 /**
  * 이메일, 닉네임, 비밀번호, 비밀번호 확인 입력 폼을 제공하며, react-hook-form으로 폼 상태를 관리합니다.
@@ -62,7 +63,7 @@ export default function SignupClient() {
         if (error instanceof ApiError) {
           setError('root', {
             type: 'server',
-            message: error.message.replace(/\.$/, ''), // 마지막 온점 제거
+            message: removeDotSuffix(error.message), // 마지막 온점 제거
           });
         } else {
           // 네트워크 에러 등

--- a/src/shared/utils/stringFormat.ts
+++ b/src/shared/utils/stringFormat.ts
@@ -1,1 +1,2 @@
+/** 마지막 온점 제거 함수 */
 export const removeDotSuffix = (message: string): string => message.replace(/\.$/, '');

--- a/src/shared/utils/stringFormat.ts
+++ b/src/shared/utils/stringFormat.ts
@@ -1,0 +1,1 @@
+export const removeDotSuffix = (message: string): string => message.replace(/\.$/, '');


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #307

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- FormField에 errorMessage prop 추가로 필드별 검증 에러 표시
- 상태 코드별 에러 처리: 404는 서버 메시지, 400은 고정 메시지 사용
- 서버 에러 메시지 마지막 온점 제거로 형식 통일

### 스크린샷 (선택)
<img width="359" height="285" alt="스크린샷 2026-05-16 14 31 28" src="https://github.com/user-attachments/assets/8e68f495-a1db-487d-94bd-496a4c949bd0" />
<img width="393" height="349" alt="스크린샷 2026-05-16 14 31 03" src="https://github.com/user-attachments/assets/d520b963-2be9-4982-a6b6-bb5c72d8970b" />
<img width="422" height="340" alt="스크린샷 2026-05-16 14 31 12" src="https://github.com/user-attachments/assets/76fab3cf-7355-4448-ae52-be618874654c" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
