### PR TITLE
[🚨 QA/#309] 스케줄 아코디언 닫힘 상태 시 Caret 아이콘 수직 정렬 어긋남 수정

### DIFF
--- a/src/features/my-page/activity-form/common/ui/schedule-selector/ScheduleCard.tsx
+++ b/src/features/my-page/activity-form/common/ui/schedule-selector/ScheduleCard.tsx
@@ -69,7 +69,10 @@ export default function ScheduleCard({
       >
         <div className="flex items-center gap-1">
           <CaretDownIcon
-            className={`h-6 w-6 text-gray-950 transition-transform duration-200 ${!isExpanded ? '-rotate-90' : ''}`}
+            className={cn(
+              'h-6 w-6 shrink-0 text-gray-950 transition-transform duration-200',
+              !isExpanded && '-translate-y-1 -rotate-90'
+            )}
           />
           <h4 className="typo-16-bold text-black">{format(date, 'yyyy년 MM월 dd일')}</h4>
         </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #309 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

체험 등록/수정 페이지의 스케줄 아코디언이 닫힐 때 Caret 아이콘의 수직 정렬이 맞지 않는 버그를 수정함.
아코디언이 닫힌 상태일 때 `-translate-y-1` 속성을 추가하여 중앙으로 끌어올림

### 스크린샷 (선택)

<img width="418" height="52" alt="image" src="https://github.com/user-attachments/assets/10122d81-e3ef-40ad-bc26-259f12dcd63c" />
<img width="407" height="45" alt="image" src="https://github.com/user-attachments/assets/07ab1cb4-dedf-4270-a206-a1a1c1ca72e6" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
