### PR TITLE
[🚨QA#302] 체험 상세 헤더 드롭다운이 탭바 뒤에 가려지는 현상 수정

### DIFF
--- a/src/features/activity/activity-detail/ui/tab/ActivityTabSection.tsx
+++ b/src/features/activity/activity-detail/ui/tab/ActivityTabSection.tsx
@@ -147,7 +147,7 @@ export default function ActivityTabSection({
 
   return (
     <div className={cn(className)}>
-      <div ref={tabBarRef} className="sticky top-12 layer-header bg-white md:top-20">
+      <div ref={tabBarRef} className="sticky top-12 layer-base bg-white md:top-20">
         <TabBar
           tabs={TABS}
           activeTab={activeTab}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #302 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

sticky 탭바가 새로운 stacking context를 형성해 헤더 드롭다운이 탭바 뒤에 가려지는 문제를 수정했습니다.
- `ActivityTabSection` 탭바의 `layer-header` → `layer-base`로 변경해 stacking context 충돌 해소

### 스크린샷 (선택)
<img width="622" height="173" alt="image" src="https://github.com/user-attachments/assets/563b39c5-881c-4726-984d-676d7731d6d3" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
