### PR TITLE
[🚨 QA/#313] SelectDropdown Item UI 깨지는 현상 해결

### DIFF
--- a/src/shared/ui/dropdown/select/SelectDropdownContent.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdownContent.tsx
@@ -15,8 +15,13 @@ type SelectDropdownContentProps = WithChildren & {
 };
 
 const dropdownContentVariants = {
-  basic: 'max-h-83 w-full overflow-y-auto rounded-2xl border border-gray-100 p-3 scrollbar-thin',
+  basic: 'w-full rounded-2xl border border-gray-100',
   shadow: dropdownListShadowStyle,
+};
+
+const dropdownScrollAreaVariants = {
+  basic: 'max-h-83 w-full overflow-y-auto overflow-x-hidden p-3 scrollbar-thin',
+  shadow: '',
 };
 
 /**
@@ -36,12 +41,14 @@ export default function SelectDropdownContent({ children, className }: SelectDro
   }
 
   return (
-    <ul
-      role="listbox"
-      aria-labelledby={triggerId}
-      className={cn(dropdownListBase, dropdownContentVariants[variants], className)}
-    >
-      {children}
-    </ul>
+    <div className={cn(dropdownListBase, dropdownContentVariants[variants], className)}>
+      <ul
+        role="listbox"
+        aria-labelledby={triggerId}
+        className={cn('flex w-full flex-col gap-1', dropdownScrollAreaVariants[variants])}
+      >
+        {children}
+      </ul>
+    </div>
   );
 }

--- a/src/shared/ui/dropdown/select/SelectDropdownContent.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdownContent.tsx
@@ -20,7 +20,7 @@ const dropdownContentVariants = {
 };
 
 const dropdownScrollAreaVariants = {
-  basic: 'max-h-83 w-full overflow-y-auto overflow-x-hidden p-3 scrollbar-thin',
+  basic: 'max-h-83 overflow-y-auto overflow-x-hidden p-3 scrollbar-thin',
   shadow: '',
 };
 

--- a/src/shared/ui/dropdown/select/SelectDropdownItem.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdownItem.tsx
@@ -99,7 +99,9 @@ export default function SelectDropdownItem<T = string>({
       onClick={selectOption}
       onKeyDown={handleKeyDown}
     >
-      {children}
+      <span className="block max-w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+        {children}
+      </span>
     </li>
   );
 }

--- a/src/shared/ui/dropdown/select/SelectDropdownItem.tsx
+++ b/src/shared/ui/dropdown/select/SelectDropdownItem.tsx
@@ -99,9 +99,7 @@ export default function SelectDropdownItem<T = string>({
       onClick={selectOption}
       onKeyDown={handleKeyDown}
     >
-      <span className="block max-w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
-        {children}
-      </span>
+      <span className="block max-w-full min-w-0 truncate">{children}</span>
     </li>
   );
 }

--- a/src/shared/ui/dropdown/styles/dropdownItem.ts
+++ b/src/shared/ui/dropdown/styles/dropdownItem.ts
@@ -2,7 +2,7 @@
  * 드롭다운 아이템 스타일 상수들
  */
 
-export const dropdownItemBase = 'cursor-pointer truncate typo-16-medium';
+export const dropdownItemBase = 'cursor-pointer w-full typo-16-medium';
 export const dropdownItemHoverBase = 'hover:bg-primary-50 hover:text-primary-500';
 export const dropdownItemShadowStyle =
   'max-w-30 rounded-md px-3 py-1 typo-16-medium text-gray-900 text-center whitespace-nowrap hover:font-semibold';


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #313 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

스크롤이 있는 드롭다운과 말줄임이 필요한 드롭다운 모두 가능하도록 UI가 깨지는 문제를 해결했습니다

**문제 상황**

<img width="871" height="478" alt="image" src="https://github.com/user-attachments/assets/a4fae5dd-ec10-43a3-b31b-cad4207ca452" />


### 스크린샷 (선택)

스크롤 있는 드롭다운
<img width="737" height="467" alt="image" src="https://github.com/user-attachments/assets/5a9d3081-f52c-4d0c-a256-178d1f33e3b2" />

말줄임이 필요한 경우
<img width="669" height="430" alt="image" src="https://github.com/user-attachments/assets/2cd1fd7d-a830-4b7c-b18d-d99a0bc15902" />


### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
