### PR TITLE
[🚨 QA/#318] 로그인 페이지 상하단 패딩 추가

### DIFF
--- a/src/app/(public)/(auth)/layout.tsx
+++ b/src/app/(public)/(auth)/layout.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { usePathname } from 'next/navigation';
 import AuthBranding from '@/app/(public)/(auth)/ui/AuthBranding';
 import GuestGuard from '@/features/auth/guards/GuestGuard';
 import { cn } from '@/shared/utils/cn';
@@ -14,12 +13,9 @@ export default function AuthLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const pathname = usePathname();
-  const isSignupPage = pathname.includes('/signup');
-
   return (
     <main className="flex min-h-dvh w-full items-center justify-center xl:justify-between">
-      <div className={cn('mx-auto w-full max-w-187 px-6 md:px-13.5', isSignupPage && 'py-20')}>
+      <div className={cn('mx-auto w-full max-w-187 px-6 py-20 md:px-13.5')}>
         <GuestGuard>{children}</GuestGuard>
       </div>
       <div

--- a/src/app/(public)/(auth)/layout.tsx
+++ b/src/app/(public)/(auth)/layout.tsx
@@ -1,4 +1,3 @@
-'use client';
 import AuthBranding from '@/app/(public)/(auth)/ui/AuthBranding';
 import GuestGuard from '@/features/auth/guards/GuestGuard';
 import { cn } from '@/shared/utils/cn';
@@ -15,7 +14,7 @@ export default function AuthLayout({
 }>) {
   return (
     <main className="flex min-h-dvh w-full items-center justify-center xl:justify-between">
-      <div className={cn('mx-auto w-full max-w-187 px-6 py-20 md:px-13.5')}>
+      <div className="mx-auto w-full max-w-187 px-6 py-20 md:px-13.5">
         <GuestGuard>{children}</GuestGuard>
       </div>
       <div


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #318

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

로그인 페이지 상하단 패딩값 추가(회원가입 페이지랑 동일한 값으로 적용했습니다)

### 스크린샷 (선택)
<img width="683" height="470" alt="스크린샷 2026-05-17 00 25 47" src="https://github.com/user-attachments/assets/bdda54ab-3ba1-4125-9085-01353065bfaa" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
