### PR TITLE
[🚨 QA/#320] 당일 스케줄 등록 시 과거 시간 노출 버그 수정

### DIFF
--- a/src/features/my-page/activity-form/common/ui/schedule-selector/ScheduleCard.tsx
+++ b/src/features/my-page/activity-form/common/ui/schedule-selector/ScheduleCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { format } from 'date-fns';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { DURATIONS, START_TIMES } from '@/features/my-page/activity-form/common/constants/schedule';
 import { useScheduleCard } from '@/features/my-page/activity-form/common/hooks/useScheduleCard';
 import TimeSlotChip from '@/features/my-page/activity-form/common/ui/schedule-selector/TimeSlotChip';
@@ -32,11 +32,11 @@ type ScheduleCardProps = {
  *
  * @example
  * <ScheduleCard
- *   date={new Date()}
- *   slots={[{ startTime: '09:00', endTime: '11:00' }]}
- *   onRemoveCard={() => handleRemoveGroup('2026-05-12')}
- *   onAddSlot={(newSlot) => handleAddSlot(index, newSlot)}
- *   onRemoveSlot={(slotIndex) => handleRemoveSlot(index, slotIndex)}
+ * date={new Date()}
+ * slots={[{ startTime: '09:00', endTime: '11:00' }]}
+ * onRemoveCard={() => handleRemoveGroup('2026-05-12')}
+ * onAddSlot={(newSlot) => handleAddSlot(index, newSlot)}
+ * onRemoveSlot={(slotIndex) => handleRemoveSlot(index, slotIndex)}
  * />
  */
 export default function ScheduleCard({
@@ -50,7 +50,10 @@ export default function ScheduleCard({
   const { tempStartTime, tempDuration, overlapError, handleStartTimeChange, handleDurationChange } =
     useScheduleCard({ slots, onAddSlot });
 
-  const availableStartTimes = getAvailableStartTimes(date, START_TIMES);
+  // date가 변경될 때만 필터링 로직을 재실행하도록 useMemo 적용
+  const availableStartTimes = useMemo(() => {
+    return getAvailableStartTimes(date, START_TIMES);
+  }, [date]);
 
   return (
     <div className="flex w-full flex-col rounded-2xl border border-gray-100 bg-white">

--- a/src/features/my-page/activity-form/common/ui/schedule-selector/ScheduleCard.tsx
+++ b/src/features/my-page/activity-form/common/ui/schedule-selector/ScheduleCard.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { DURATIONS, START_TIMES } from '@/features/my-page/activity-form/common/constants/schedule';
 import { useScheduleCard } from '@/features/my-page/activity-form/common/hooks/useScheduleCard';
 import TimeSlotChip from '@/features/my-page/activity-form/common/ui/schedule-selector/TimeSlotChip';
+import { getAvailableStartTimes } from '@/features/my-page/activity-form/common/utils/schedule';
 import { Slot } from '@/features/my-page/activity-form/types';
 import { CaretDownIcon, TrashIcon } from '@/shared/assets/icons';
 import {
@@ -48,6 +49,8 @@ export default function ScheduleCard({
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
   const { tempStartTime, tempDuration, overlapError, handleStartTimeChange, handleDurationChange } =
     useScheduleCard({ slots, onAddSlot });
+
+  const availableStartTimes = getAvailableStartTimes(date, START_TIMES);
 
   return (
     <div className="flex w-full flex-col rounded-2xl border border-gray-100 bg-white">
@@ -98,7 +101,7 @@ export default function ScheduleCard({
                   <SelectDropdownValue placeholder="시작 시간" />
                 </SelectDropdownTrigger>
                 <SelectDropdownContent>
-                  {START_TIMES.map((time) => (
+                  {availableStartTimes.map((time) => (
                     <SelectDropdownItem key={time} value={time}>
                       {time}
                     </SelectDropdownItem>

--- a/src/features/my-page/activity-form/common/utils/schedule.test.ts
+++ b/src/features/my-page/activity-form/common/utils/schedule.test.ts
@@ -2,6 +2,7 @@ import {
   isExceedingMidnight,
   calculateEndTime,
   findOverlapSlot,
+  getAvailableStartTimes,
 } from '@/features/my-page/activity-form/common/utils/schedule';
 
 describe('schedule utils', () => {
@@ -47,6 +48,43 @@ describe('schedule utils', () => {
     it('기존 슬롯과 겹치지 않는 빈 시간대면 undefined를 반환한다', () => {
       const overlap = findOverlapSlot(existingSlots, '11:00', '13:00');
       expect(overlap).toBeUndefined();
+    });
+  });
+
+  describe('getAvailableStartTimes', () => {
+    beforeEach(() => {
+      // 시간에 의존하는 함수이기 때문에 가짜 시간 사용
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      // 테스트가 끝나면 실제 시간으로 되돌림
+      jest.useRealTimers();
+    });
+
+    it('오늘 날짜를 선택하면 현재 시간 이하의 시간대는 필터링한다', () => {
+      // 현재 시간을 26년 5월 20일 15시로 고정
+      jest.setSystemTime(new Date('2026-05-20T15:30:00'));
+
+      const today = new Date('2026-05-20T00:00:00'); // 달력에서 오늘 선택
+      const allTimes = ['13:00', '14:00', '15:00', '16:00', '17:00'];
+
+      const result = getAvailableStartTimes(today, allTimes);
+
+      // 16시부터 남아있어야 함
+      expect(result).toEqual(['16:00', '17:00']);
+    });
+
+    it('미래의 날짜를 선택하면 시간대 필터링 없이 모두 반환한다', () => {
+      jest.setSystemTime(new Date('2026-05-20T15:30:00'));
+
+      const tomorrow = new Date('2026-05-21T00:00:00'); // 내일 선택
+      const allTimes = ['09:00', '12:00', '15:00'];
+
+      const result = getAvailableStartTimes(tomorrow, allTimes);
+
+      // 미래 날짜이므로 과거/현재 상관없이 전부 통과되어야 함
+      expect(result).toEqual(['09:00', '12:00', '15:00']);
     });
   });
 });

--- a/src/features/my-page/activity-form/common/utils/schedule.ts
+++ b/src/features/my-page/activity-form/common/utils/schedule.ts
@@ -1,4 +1,24 @@
+import { format } from 'date-fns';
 import { Slot } from '@/features/my-page/activity-form/types';
+
+/**
+ * 선택된 날짜에 따라 예약 가능한 시작 시간 목록을 필터링합니다.
+ * 당일일 경우 현재 시간 이하의 슬롯은 제외하여 미래의 시간만 반환합니다.
+ *
+ * @param date 선택된 달력 날짜
+ * @param allTimes 전체 시작 시간 배열
+ */
+export const getAvailableStartTimes = (date: Date, allTimes: string[]): string[] => {
+  const now = new Date();
+  const isToday = format(date, 'yyyy-MM-dd') === format(now, 'yyyy-MM-dd');
+  const currentHour = now.getHours();
+
+  return allTimes.filter((time) => {
+    if (!isToday) return true;
+    const [hour] = time.split(':').map(Number);
+    return hour > currentHour;
+  });
+};
 
 /** 24시간 초과 여부 확인 */
 export const isExceedingMidnight = (start: string, duration: number): boolean => {

--- a/src/features/my-page/activity-form/common/utils/schedule.ts
+++ b/src/features/my-page/activity-form/common/utils/schedule.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { isSameDay } from 'date-fns';
 import { Slot } from '@/features/my-page/activity-form/types';
 
 /**
@@ -7,16 +7,17 @@ import { Slot } from '@/features/my-page/activity-form/types';
  *
  * @param date 선택된 달력 날짜
  * @param allTimes 전체 시작 시간 배열
+ * @example
+ * getAvailableStartTimes(new Date(), ['09:00', '10:00', '11:00'])
  */
 export const getAvailableStartTimes = (date: Date, allTimes: string[]): string[] => {
   const now = new Date();
-  const isToday = format(date, 'yyyy-MM-dd') === format(now, 'yyyy-MM-dd');
-  const currentHour = now.getHours();
+  const isToday = isSameDay(date, now);
 
   return allTimes.filter((time) => {
     if (!isToday) return true;
     const [hour] = time.split(':').map(Number);
-    return hour > currentHour;
+    return hour > now.getHours();
   });
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #320 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

체험 등록/수정 페이지 "예약 가능한 시간대"에서 오늘 날짜 선택 시 현재시간을 포함한 이전 시간이 노출되지 않도록 변경함 (예: 7시 기준 -> 7시 차단, 8시부터 노출)
- 선택된 날짜가 오늘일 경우 현재 시간 이하의 항목을 드롭다운에서 숨기는 함수 구현
- 오늘 날짜 선택 시 과거시간 필터링 여부와 미래 날짜 선택 시 전체 시간 정상 노출 여부를 검증하는 테스트 추가
  - 겹치는 이름이 있어서 `pnpm test utils/schedule`로 테스트 가능합니다!

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
