### PR TITLE
[🚨QA/#323] 모바일 환경 검색 인풋 포커스 시 자동 줌인 처리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -66,12 +66,10 @@ const pretendard = localFont({
   variable: '--font-pretendard',
 });
 
-// 모바일 입력 필드 자동 줌 방지
+// 기본 뷰포트 설정
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1, // iOS Safari의 input 자동 줌인 방지
-  userScalable: false,
 };
 
 export default function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -66,6 +66,14 @@ const pretendard = localFont({
   variable: '--font-pretendard',
 });
 
+// 모바일 입력 필드 자동 줌 방지
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1, // iOS Safari의 input 자동 줌인 방지
+  userScalable: false,
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import localFont from 'next/font/local';
 import Script from 'next/script';
 import AuthSessionSync from '@/features/auth/providers/AuthSessionSync';
@@ -67,7 +67,7 @@ const pretendard = localFont({
 });
 
 // 모바일 입력 필드 자동 줌 방지
-export const viewport = {
+export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1, // iOS Safari의 input 자동 줌인 방지

--- a/src/features/activity/activities/ui/ActivitiesPageHeader.tsx
+++ b/src/features/activity/activities/ui/ActivitiesPageHeader.tsx
@@ -21,7 +21,7 @@ export default function ActivitiesPageHeader() {
     <div className="flex flex-col gap-3 sm:gap-9">
       {/* SearchInput — 모바일에서만 상단 full width */}
       <div className="sm:hidden">
-        <SearchInput className="h-14! w-full rounded-2xl! px-4! typo-14-medium! shadow-none" />
+        <SearchInput className="h-14! w-full rounded-2xl! px-4! shadow-none" />
       </div>
 
       {/* PageHeader + (모바일: SortSelectDropdown | 데스크탑: SearchInput) */}

--- a/src/shared/ui/search-input/SearchInputField.tsx
+++ b/src/shared/ui/search-input/SearchInputField.tsx
@@ -30,7 +30,7 @@ const SearchInputUi = forwardRef<HTMLInputElement, SearchInputUiProps>(
           aria-label="검색어 입력"
           className={cn(
             'field-surface field-input',
-            'h-15.5 w-full rounded-[20px] px-5 py-5.5 pr-14 typo-14-medium shadow-drop md:h-17.5 md:rounded-3xl md:px-8 md:py-6 md:pr-22 md:typo-18-medium',
+            'h-15.5 w-full rounded-[20px] px-5 py-5.5 pr-14 typo-16-medium shadow-drop md:h-17.5 md:rounded-3xl md:px-8 md:py-6 md:pr-22 md:typo-18-medium',
             className
           )}
         />


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #323

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 검색 인풋 기본 폰트 사이즈를 14px → 16px로 수정
- 자동 줌인 방지 viewport 메타 태그 추가 ( + 제미나이 리뷰 반영으로 기본 뷰포트 설정만 반영됐습니다)

iOS에서는 입력 필드의 폰트 크기가 16px 미만일 경우 글자가 너무 작다고 판단하여 자동으로 화면을 확대시킨다고 합니당
그래서 기본 Input 폰트 사이즈도 16px이라 디자인 측면에서 크게 벗어나지 않을거같아서 폰트 사이즈를 수정하고
안전장치로 viewport 설정 추가했습니다

### 스크린샷 (선택)
<img width="563" height="568" alt="KakaoTalk_Photo_2026-05-17-14-31-48" src="https://github.com/user-attachments/assets/43334ee4-6666-43f2-bbfa-574833f9f5be" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
