### PR TITLE
[🚨 QA/#328] 수정 페이지에서 로그아웃 시 404 에러 노출 버그 수정

### DIFF
--- a/src/features/my-page/activity-form/edit/ui/ActivityEditClient.tsx
+++ b/src/features/my-page/activity-form/edit/ui/ActivityEditClient.tsx
@@ -23,7 +23,7 @@ export default function ActivityEditClient({ activityId }: ActivityEditClientPro
   const { submitActivityEdit, isPending } = useActivityEditSubmit(activityId, originalData);
 
   if (hasHydrated && originalData) {
-    if (user?.id !== originalData.userId) {
+    if (user && user.id !== originalData.userId) {
       notFound();
     }
   }

--- a/src/features/my-page/activity-form/edit/ui/ActivityEditClient.tsx
+++ b/src/features/my-page/activity-form/edit/ui/ActivityEditClient.tsx
@@ -22,12 +22,6 @@ export default function ActivityEditClient({ activityId }: ActivityEditClientPro
   const { data: originalData } = useActivityDetail(activityId);
   const { submitActivityEdit, isPending } = useActivityEditSubmit(activityId, originalData);
 
-  if (hasHydrated && originalData) {
-    if (user && user.id !== originalData.userId) {
-      notFound();
-    }
-  }
-
   const initialData = useMemo(() => {
     if (!originalData) return undefined;
 
@@ -51,6 +45,14 @@ export default function ActivityEditClient({ activityId }: ActivityEditClientPro
         })) || [],
     };
   }, [originalData]);
+
+  if (hasHydrated && originalData) {
+    if (!user) return null;
+
+    if (user.id !== originalData.userId) {
+      notFound();
+    }
+  }
 
   return (
     <ActivityFormPageShell


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #328 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

로그아웃 시 라우팅보다 `user` 가 `null`이 되는 전역 상태 업데이트 및 컴포넌트 리렌더링이 더 빠르게 발생하기 때문에 `user`가 `null`이 된 상태로 `ActivityEditClient`가 리렌더링되면서, 작성자가 일치하지 않아 404에러가 발생하므로, `if (user && user.id !== originalData.userId)` 형태로 조건문을 수정하여 로그아웃으로 `user`가 `null`이 되었을 때는 404에러를 발생시키지 않도록 함

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
