### PR TITLE
[🚨QA/#331] 바텀 시트 내부 컨텐츠 잘릴 시 스크롤 처리

### DIFF
--- a/src/features/my-page/reservation-status/ui/pannel/ReservationPanel.tsx
+++ b/src/features/my-page/reservation-status/ui/pannel/ReservationPanel.tsx
@@ -60,7 +60,12 @@ export default function ReservationPanel({
   // 모바일: BottomSheet
   if (isMobile) {
     return (
-      <BottomSheet isOpen={isOpen} onClose={onClose} ariaLabel="예약 현황">
+      <BottomSheet
+        isOpen={isOpen}
+        onClose={onClose}
+        ariaLabel="예약 현황"
+        surfaceClassName="h-auto! max-h-[90dvh]!"
+      >
         <div className="px-6 pt-2 pb-7.5">{content}</div>
       </BottomSheet>
     );

--- a/src/features/my-page/reservation-status/ui/pannel/ReservationPanelContent.tsx
+++ b/src/features/my-page/reservation-status/ui/pannel/ReservationPanelContent.tsx
@@ -211,7 +211,7 @@ export default function ReservationPanelContent({
             {/* 카드 목록 - 무한스크롤 적용 */}
             <div className="flex min-h-0 flex-1 flex-col md:w-1/2 lg:w-full">
               <FormLabel className="mt-5 mb-3 typo-18-bold lg:mt-7.5">예약내역</FormLabel>
-              <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="min-h-0 flex-1">
                 <div className="flex flex-col gap-3">
                   {isLoading && !showReservationsSkeleton ? null : showReservationsSkeleton ? (
                     <>

--- a/src/features/my-page/reservation-status/ui/pannel/ReservationPanelContent.tsx
+++ b/src/features/my-page/reservation-status/ui/pannel/ReservationPanelContent.tsx
@@ -170,7 +170,7 @@ export default function ReservationPanelContent({
       </div>
 
       {/* 콘텐츠 - 최초 진입 시 전체 로딩 */}
-      <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         {isAllLoading ? (
           <ReservationPanelContentSkeleton />
         ) : availableSchedules.length === 0 ? (

--- a/src/features/reservation/activity-panel/ui/ReservationBar.tsx
+++ b/src/features/reservation/activity-panel/ui/ReservationBar.tsx
@@ -118,10 +118,7 @@ export default function ReservationBar({
         isOpen={isOpen}
         onClose={handleClose}
         ariaLabel="예약 날짜 선택"
-        surfaceClassName={cn(
-          'h-auto! max-h-[90dvh]! px-7.5',
-          step === 'headcount' && 'max-h-none!'
-        )}
+        surfaceClassName={cn('px-7.5', step === 'headcount' && 'max-h-none!')}
       >
         <div className="flex-1 overflow-y-auto">
           {step === 'schedule' ? (

--- a/src/shared/ui/bottom-sheet/BottomSheet.tsx
+++ b/src/shared/ui/bottom-sheet/BottomSheet.tsx
@@ -47,7 +47,7 @@ export default function BottomSheet({
           variant="sheet"
           tone="surface"
           elevation="card"
-          className={cn('h-auto!', surfaceClassName)}
+          className={cn('h-auto! max-h-[90dvh] overflow-y-auto', surfaceClassName)}
           style={{
             transform: `translateY(${dragY}px)`,
             transition: dragY === 0 ? 'transform 0.3s ease' : 'none',

--- a/src/shared/ui/bottom-sheet/BottomSheet.tsx
+++ b/src/shared/ui/bottom-sheet/BottomSheet.tsx
@@ -47,21 +47,26 @@ export default function BottomSheet({
           variant="sheet"
           tone="surface"
           elevation="card"
-          className={cn('h-auto! max-h-[90dvh] overflow-y-auto', surfaceClassName)}
+          className={cn('max-h-[90dvh] overflow-hidden', surfaceClassName)}
           style={{
             transform: `translateY(${dragY}px)`,
             transition: dragY === 0 ? 'transform 0.3s ease' : 'none',
             ...surfaceStyle,
           }}
         >
-          <div role="dialog" aria-modal="true" aria-label={ariaLabel} className="flex flex-col">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={ariaLabel}
+            className="flex h-full flex-col"
+          >
             {/* 핸들바 */}
             <div className="flex shrink-0 justify-center pt-4 pb-3" {...handlers}>
               <div className="h-1 w-19 rounded-full bg-gray-300" />
             </div>
 
             {/* 콘텐츠 */}
-            <div className="flex min-h-0 flex-col overflow-y-auto">{children}</div>
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">{children}</div>
           </div>
         </OverlaySurface>
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #331 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 체험 상세 예약하기 패널 내 바텀시트 높이보다 컨텐츠 길 경우 스크롤 처리
- 바텀시트 max-h-[90dvh] 지정 
- 예약 현황 페이지 예약 정보 패널 드롭 박스 및 내부 길어질 경우 내부 스크롤 처리

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
