### PR TITLE
[🚨QA/#334] 예약 내역 리뷰 모달 모바일일 때 좌우 여백 추가

### DIFF
--- a/src/features/reservation/reservation-list/ui/review-modal/ReviewModal.tsx
+++ b/src/features/reservation/reservation-list/ui/review-modal/ReviewModal.tsx
@@ -101,7 +101,7 @@ export default function ReviewModal({
       ariaLabel="리뷰 작성"
       position="center"
       variant="dialog"
-      surfaceClassName="w-96.25"
+      surfaceClassName="w-[calc(100%-32px)] max-w-96.25"
       contentClassName="dialog-surface-animation rounded-[30px] px-7.5 py-8"
       closeOnOverlayClick={!shouldBlockAutoClose}
       closeOnEsc={!shouldBlockAutoClose}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #334

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 모바일일 때 리뷰 모달 좌우 여백 추가

### 스크린샷 (선택)

<img width="186" height="451" alt="image" src="https://github.com/user-attachments/assets/769d8406-d293-42c1-87bc-ddf8cbf2b3bf" />


### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
