### PR TITLE
[🚨 QA/#339] 마이페이지 모바일/ 상세페이지 헤더 배경색 white로 변경

### DIFF
--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -68,25 +68,24 @@ type HeaderProps = {
  * @param props.className - 추가 클래스
  */
 export default function Header({ isLoggedIn = false, user, className, onLogout }: HeaderProps) {
-  const pathname = usePathname();
+  const pathname = usePathname() ?? '';
   const isScrollThemedPage = pathname === '/' || pathname === '/search';
   const { isScrolled } = useScroll({ isEnabled: isScrollThemedPage });
 
   const theme: HeaderTheme = isScrollThemedPage && !isScrolled ? 'primary' : 'light';
   const LogoWrapper = pathname === '/' || pathname === '/search' ? 'h1' : 'div';
   const isMyPage = pathname.startsWith('/mypage');
-  const isActivityDetail = /^\/activity\/\d+/.test(pathname ?? '');
-  const shouldUseSolidLightBg = theme === 'light' && (isActivityDetail || isMyPage);
-  const myPageLightBgOverrideClassName =
-    theme === 'light' && isMyPage && !isActivityDetail ? 'md:bg-white/60 md:backdrop-blur' : '';
+  const isActivityDetail = pathname.startsWith('/activity/');
+  const shouldUseSolidLightBg = isActivityDetail || isMyPage;
+  const myPageLightBgOverrideClassName = isMyPage ? 'md:bg-white/60 md:backdrop-blur' : '';
 
   return (
     <header
       className={cn(
         'sticky top-0 layer-header',
         headerVariants({ theme }),
-        shouldUseSolidLightBg && 'bg-white backdrop-blur-none',
-        myPageLightBgOverrideClassName,
+        theme === 'light' && shouldUseSolidLightBg && 'bg-white backdrop-blur-none',
+        theme === 'light' && myPageLightBgOverrideClassName,
         className
       )}
     >

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -74,9 +74,22 @@ export default function Header({ isLoggedIn = false, user, className, onLogout }
 
   const theme: HeaderTheme = isScrollThemedPage && !isScrolled ? 'primary' : 'light';
   const LogoWrapper = pathname === '/' || pathname === '/search' ? 'h1' : 'div';
+  const isMyPage = pathname.startsWith('/mypage');
+  const isActivityDetail = /^\/activity\/\d+/.test(pathname ?? '');
+  const shouldUseSolidLightBg = theme === 'light' && (isActivityDetail || isMyPage);
+  const myPageLightBgOverrideClassName =
+    theme === 'light' && isMyPage && !isActivityDetail ? 'md:bg-white/60 md:backdrop-blur' : '';
 
   return (
-    <header className={cn('sticky top-0 layer-header', headerVariants({ theme }), className)}>
+    <header
+      className={cn(
+        'sticky top-0 layer-header',
+        headerVariants({ theme }),
+        shouldUseSolidLightBg && 'bg-white backdrop-blur-none',
+        myPageLightBgOverrideClassName,
+        className
+      )}
+    >
       <div className="shell-inner">
         <LogoWrapper className="leading-none">
           <Logo variant={logoVariantByTheme[theme]} className="h-6 md:h-7" />


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #339

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 마이페이지 모바일/ 상세 페이지에서 헤더 색상 white로 변경

### 스크린샷 (선택)

- 상세페이지

<img width="757" height="355" alt="image" src="https://github.com/user-attachments/assets/718472a5-a635-448e-8548-6821c2b6d6f9" />

- 마이페이지 모바일

<img width="274" height="317" alt="image" src="https://github.com/user-attachments/assets/12d851af-98bf-46b3-9f93-b03ca764bc96" />


### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
