### PR TITLE
[🚨 QA/#341] 예약 내역 만료 state 뱃지 UI 깨짐 해결

### DIFF
--- a/src/features/reservation/reservation-list/constants/messages.ts
+++ b/src/features/reservation/reservation-list/constants/messages.ts
@@ -1,3 +1,4 @@
 export const RESERVATION_UI_MESSAGES = {
+  EXPIRED_PENDING_BADGE_LABEL: '만료(미승인)',
   PENDING_CHANGE_DISABLED_EXPIRED: '승인 기한이 지나 예약 변경은 할 수 없어요.',
 } as const;

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
@@ -45,13 +45,10 @@ export default function ReservationCardInfo({
       <div className="flex items-center justify-between gap-3">
         {/* 예약 상태 뱃지 */}
         <StateBadge
-          status={status}
+          status={isExpiredPending ? 'declined' : status}
           labelOverride={isExpiredPending ? '만료(미승인)' : undefined}
           className="w-fit"
         />
-        {isExpiredPending && (
-          <p className="typo-12-medium text-gray-500">{pendingDisabledMessage}</p>
-        )}
       </div>
 
       {/* 체험명 + 예약 일정 */}

--- a/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
+++ b/src/features/reservation/reservation-list/ui/reservation-card/ReservationCardInfo.tsx
@@ -46,7 +46,9 @@ export default function ReservationCardInfo({
         {/* 예약 상태 뱃지 */}
         <StateBadge
           status={isExpiredPending ? 'declined' : status}
-          labelOverride={isExpiredPending ? '만료(미승인)' : undefined}
+          labelOverride={
+            isExpiredPending ? RESERVATION_UI_MESSAGES.EXPIRED_PENDING_BADGE_LABEL : undefined
+          }
           className="w-fit"
         />
       </div>

--- a/src/shared/ui/state-badge/StateBadge.tsx
+++ b/src/shared/ui/state-badge/StateBadge.tsx
@@ -57,7 +57,7 @@ export default function StateBadge({ status, labelOverride, className }: StateBa
   return (
     <span
       className={cn(
-        'inline-flex h-6 items-center rounded-full px-2 pt-px align-middle typo-13-bold',
+        'inline-flex h-6 items-center rounded-full px-2 pt-px align-middle typo-13-bold whitespace-nowrap',
         badgeClassName,
         className
       )}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #341

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 예약 내역 만료 시 state 뱃지의 색상을 거절 색상과 동일하게 변경
- 만료 시 뱃지의 UI가 깨지는 문제를 nowrap을 사용해서 방지
- 또한 모바일에서 승인 기한 만료에 대한 설명이 깨져서 제거하고 버튼의 툴팁으로만 나오게 변경

### 스크린샷 (선택)

<img width="673" height="238" alt="image" src="https://github.com/user-attachments/assets/09e6fe61-b0a6-40d3-a790-f891f5f44c88" />


### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
