### PR TITLE
[🚨 QA/#346] 체험 삭제 실패시 서버 메시지 토스트 노출

### DIFF
--- a/src/features/my-page/common/ui/DeleteActivityDialog.tsx
+++ b/src/features/my-page/common/ui/DeleteActivityDialog.tsx
@@ -28,6 +28,7 @@ export default function DeleteActivityDialog({ id, isOpen, onClose }: DeleteActi
       closeOnConfirm={false}
       onCancel={onClose}
       onConfirm={async () => {
+        if (deleteMutation.isPending) return;
         try {
           await deleteMutation.mutateAsync(id);
           showToast('check', '체험이 삭제되었습니다.');

--- a/src/features/my-page/common/ui/DeleteActivityDialog.tsx
+++ b/src/features/my-page/common/ui/DeleteActivityDialog.tsx
@@ -14,7 +14,7 @@ type DeleteActivityDialogProps = {
 
 export default function DeleteActivityDialog({ id, isOpen, onClose }: DeleteActivityDialogProps) {
   const router = useRouter();
-  const { mutate: deleteActivity } = useDeleteActivity();
+  const deleteMutation = useDeleteActivity();
   const { showToast } = useToastStore();
 
   return (
@@ -25,30 +25,30 @@ export default function DeleteActivityDialog({ id, isOpen, onClose }: DeleteActi
       description="삭제할 경우, 다시 되돌릴 수 없습니다."
       confirmText="삭제하기"
       cancelText="아니오"
+      closeOnConfirm={false}
       onCancel={onClose}
-      onConfirm={() => {
-        deleteActivity(id, {
-          onSuccess: () => {
-            showToast('check', '체험이 삭제되었습니다.');
-            router.push('/mypage/activity');
-          },
-          onError: (error) => {
-            if (error instanceof ApiError) {
-              if (error.status === 401) {
-                showToast('cancel', '로그인이 필요합니다.');
-                router.push('/login');
-                return;
-              }
-
-              showToast('cancel', error.message);
+      onConfirm={async () => {
+        try {
+          await deleteMutation.mutateAsync(id);
+          showToast('check', '체험이 삭제되었습니다.');
+          onClose();
+          router.push('/mypage/activity');
+        } catch (error) {
+          if (error instanceof ApiError) {
+            if (error.status === 401) {
+              showToast('cancel', '로그인이 필요합니다.');
+              onClose();
+              router.push('/login');
               return;
             }
 
-            const message = error instanceof Error ? error.message : '체험 삭제에 실패했습니다.';
-            showToast('cancel', message);
-          },
-        });
-        onClose();
+            showToast('cancel', error.message);
+            return;
+          }
+
+          const message = error instanceof Error ? error.message : '체험 삭제에 실패했습니다.';
+          showToast('cancel', message);
+        }
       }}
     />
   );

--- a/src/shared/ui/dialog/ConfirmDialog.tsx
+++ b/src/shared/ui/dialog/ConfirmDialog.tsx
@@ -29,7 +29,9 @@ export type ConfirmDialogProps = {
  *
  * @remarks
  * - `isOpen`/`onClose`로 제어하는 controlled 컴포넌트입니다.
- * - 버튼 클릭 시 먼저 `onClose()`로 닫고, 이후 콜백을 실행합니다.
+ * - `closeOnConfirm`에 따라 확인 버튼 클릭 시 닫힘 타이밍이 달라질 수 있습니다.
+ *   - `true`(기본값): `onClose()`로 먼저 닫은 뒤 `onConfirm`을 실행합니다.
+ *   - `false`: `onConfirm` 실행이 끝난 뒤에도 다이얼로그를 유지합니다. (필요 시 `onConfirm`에서 직접 `onClose()` 호출)
  *
  * @example
  * ```tsx

--- a/src/shared/ui/dialog/ConfirmDialog.tsx
+++ b/src/shared/ui/dialog/ConfirmDialog.tsx
@@ -14,6 +14,8 @@ export type ConfirmDialogProps = {
   onConfirm?: () => void | Promise<void>;
   /** '아니오' 버튼 클릭 시 실행할 콜백 */
   onCancel?: () => void;
+  /** 확인 버튼 클릭 시 즉시 닫을지 여부 (기본값: true) */
+  closeOnConfirm?: boolean;
   confirmText?: string;
   cancelText?: string;
   ariaLabel?: string;
@@ -54,6 +56,7 @@ export default function ConfirmDialog({
   description,
   onConfirm,
   onCancel,
+  closeOnConfirm = true,
   confirmText = '네',
   cancelText = '아니오',
   ariaLabel = '확인 다이얼로그',
@@ -65,7 +68,7 @@ export default function ConfirmDialog({
   };
 
   const handleConfirm = async () => {
-    onClose();
+    if (closeOnConfirm) onClose();
     await onConfirm?.();
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #346

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 체험 삭제 API가 400(BadRequest)로 실패할 때 서버 응답 `message`를 토스트로 노출하도록 처리했습니다

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
