### PR TITLE
[🚨 QA/#348] 체험 카드 제목 heading 태그를 prop으로 전달 가능하게 변경

### DIFF
--- a/src/features/activity/main/ui/activity-card/ActivityCard.tsx
+++ b/src/features/activity/main/ui/activity-card/ActivityCard.tsx
@@ -1,6 +1,7 @@
 import BaseCardImage from '@/shared/ui/card/base/BaseCardImage';
 import BaseCardInfo from '@/shared/ui/card/base/BaseCardInfo';
 import { cardWrapStyles } from '@/shared/ui/card/cardStyles';
+import { TitleAs } from '@/shared/ui/title/Title';
 import { cn } from '@/shared/utils/cn';
 import ActivityCardInfo from './ActivityCardInfo';
 
@@ -17,6 +18,7 @@ export type ActivityCardData = {
 };
 export type ActivityCardProps = {
   data: ActivityCardData;
+  titleTag?: TitleAs;
 };
 
 /**
@@ -36,7 +38,7 @@ export type ActivityCardProps = {
  * </div>
  * ```
  */
-export default function ActivityCard({ data }: ActivityCardProps) {
+export default function ActivityCard({ data, titleTag }: ActivityCardProps) {
   const { bannerImageUrl } = data;
 
   return (
@@ -49,7 +51,7 @@ export default function ActivityCard({ data }: ActivityCardProps) {
 
       {/* 정보 영역 */}
       <BaseCardInfo className="absolute bottom-0 p-4 md:px-7.5 md:py-5">
-        <ActivityCardInfo data={data} />
+        <ActivityCardInfo data={data} titleTag={titleTag} />
       </BaseCardInfo>
     </div>
   );

--- a/src/features/activity/main/ui/activity-card/ActivityCardInfo.tsx
+++ b/src/features/activity/main/ui/activity-card/ActivityCardInfo.tsx
@@ -1,7 +1,16 @@
 import PerPersonPrice from '@/shared/ui/price/PerPersonPrice';
 import RatingSummary from '@/shared/ui/rating-summary/RatingSummary';
-import Title from '@/shared/ui/title/Title';
-import type { ActivityCardProps } from './ActivityCard';
+import Title, { TitleAs } from '@/shared/ui/title/Title';
+
+type ActivityCardInfo = {
+  data: {
+    title: string;
+    reviewCount: number;
+    rating: number;
+    price: number;
+  };
+  titleTag?: TitleAs;
+};
 
 /**
  * 체험 카드 컴포넌트입니다.
@@ -12,14 +21,14 @@ import type { ActivityCardProps } from './ActivityCard';
  * <ActivityCardInfo data={data} />
  * ```
  */
-export default function ActivityCardInfo({ data }: ActivityCardProps) {
+export default function ActivityCardInfo({ data, titleTag = 'h3' }: ActivityCardInfo) {
   const { title, reviewCount, rating, price } = data;
   return (
     <div className="flex flex-col gap-2.5 md:gap-4.5">
       {/* 체험명 + 리뷰 요약 */}
       <div className="flex flex-col">
         {/* 제목 (길어질 경우 말줄임 처리) */}
-        <Title as="h3" size="14" weight="semibold" className="truncate md:typo-18-semibold">
+        <Title as={titleTag} size="14" weight="semibold" className="truncate md:typo-18-semibold">
           {title}
         </Title>
 

--- a/src/features/activity/main/ui/activity-card/ActivityCardInfo.tsx
+++ b/src/features/activity/main/ui/activity-card/ActivityCardInfo.tsx
@@ -2,7 +2,7 @@ import PerPersonPrice from '@/shared/ui/price/PerPersonPrice';
 import RatingSummary from '@/shared/ui/rating-summary/RatingSummary';
 import Title, { TitleAs } from '@/shared/ui/title/Title';
 
-type ActivityCardInfo = {
+type ActivityCardInfoProps = {
   data: {
     title: string;
     reviewCount: number;
@@ -21,7 +21,7 @@ type ActivityCardInfo = {
  * <ActivityCardInfo data={data} />
  * ```
  */
-export default function ActivityCardInfo({ data, titleTag = 'h3' }: ActivityCardInfo) {
+export default function ActivityCardInfo({ data, titleTag = 'h3' }: ActivityCardInfoProps) {
   const { title, reviewCount, rating, price } = data;
   return (
     <div className="flex flex-col gap-2.5 md:gap-4.5">

--- a/src/features/activity/main/ui/activity-card/ActivityCardInfo.tsx
+++ b/src/features/activity/main/ui/activity-card/ActivityCardInfo.tsx
@@ -18,7 +18,7 @@ type ActivityCardInfoProps = {
  *
  * @example
  * ```tsx
- * <ActivityCardInfo data={data} />
+ * <ActivityCardInfo data={data} titleTag="h2"/>
  * ```
  */
 export default function ActivityCardInfo({ data, titleTag = 'h3' }: ActivityCardInfoProps) {

--- a/src/features/activity/search/ui/SearchActivityList.tsx
+++ b/src/features/activity/search/ui/SearchActivityList.tsx
@@ -21,7 +21,7 @@ export default function SearchActivityList({ activities }: SearchActivityListPro
         return (
           <li key={data.id}>
             <Link href={`/activity/${data.id}`}>
-              <ActivityCard data={data} />
+              <ActivityCard data={data} titleTag="h2" />
             </Link>
           </li>
         );

--- a/src/features/activity/search/ui/SearchResultSection.tsx
+++ b/src/features/activity/search/ui/SearchResultSection.tsx
@@ -37,7 +37,7 @@ export default function SearchResultSection() {
   return (
     <>
       <div className="mb-5 md:mb-7 lg:mb-10">
-        <Title as="h2" size="18" weight="medium" className="text-gray-950 md:typo-24-medium">
+        <Title as="h1" size="18" weight="medium" className="text-gray-950 md:typo-24-medium">
           <span className="typo-18-bold md:typo-24-bold">{keyword}</span>으로 검색한 결과입니다.
         </Title>
         <p className="typo-14-medium text-gray-700 md:typo-18-medium">

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -73,7 +73,7 @@ export default function Header({ isLoggedIn = false, user, className, onLogout }
   const { isScrolled } = useScroll({ isEnabled: isScrollThemedPage });
 
   const theme: HeaderTheme = isScrollThemedPage && !isScrolled ? 'primary' : 'light';
-  const LogoWrapper = pathname === '/' || pathname === '/search' ? 'h1' : 'div';
+  const LogoWrapper = pathname === '/' ? 'h1' : 'div';
   const isMyPage = pathname.startsWith('/mypage');
   const isActivityDetail = pathname.startsWith('/activity/');
   const shouldUseSolidLightBg = isActivityDetail || isMyPage;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #348

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 기존 검색 페이지의 h1 태그였던 헤더 로고를 div로 변경
- ActivityCardProps에 titleTag prop 추가
- 기본값을 'h3'으로 설정

### 스크린샷 (선택)
<img width="800" height="425" alt="스크린샷 2026-05-17 23 10 45" src="https://github.com/user-attachments/assets/96f0c0ec-e3d8-41e7-8198-54b010be0a63" />
<img width="800" height="498" alt="스크린샷 2026-05-17 23 11 03" src="https://github.com/user-attachments/assets/960a3c86-608d-4f7a-ae69-c4be6e4725c1" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
