### PR TITLE
[🚨 QA/#355] 모바일에서 메인페이지 카테고리 전체보기 버튼 노출

### DIFF
--- a/src/features/activity/main/ui/MainCategoryList.tsx
+++ b/src/features/activity/main/ui/MainCategoryList.tsx
@@ -35,10 +35,10 @@ export default function MainCategoryList() {
         </Title>
         <Link
           href="/activities"
-          className="hidden items-center typo-20-medium text-primary-700 md:inline-flex"
+          className="inline-flex items-center typo-16-medium leading-[100%] text-primary-700 md:typo-20-medium"
         >
           전체 보기
-          <span className="flex items-center">
+          <span className="flex h-4 w-4 items-center md:h-6 md:w-6">
             <ChevronRightBlueIcon />
           </span>
         </Link>

--- a/src/features/activity/main/ui/MainCategoryList.tsx
+++ b/src/features/activity/main/ui/MainCategoryList.tsx
@@ -35,7 +35,7 @@ export default function MainCategoryList() {
         </Title>
         <Link
           href="/activities"
-          className="inline-flex items-center typo-16-medium leading-[100%] text-primary-700 md:typo-20-medium"
+          className="inline-flex items-center typo-16-medium text-primary-700 md:typo-20-medium"
         >
           전체 보기
           <span className="flex h-4 w-4 items-center md:h-6 md:w-6">

--- a/src/features/activity/main/ui/MainCategoryList.tsx
+++ b/src/features/activity/main/ui/MainCategoryList.tsx
@@ -38,7 +38,7 @@ export default function MainCategoryList() {
           className="inline-flex items-center typo-16-medium text-primary-700 md:typo-20-medium"
         >
           전체 보기
-          <span className="flex h-4 w-4 items-center md:h-6 md:w-6">
+          <span className="flex h-4 w-4 items-center justify-center md:h-6 md:w-6">
             <ChevronRightBlueIcon />
           </span>
         </Link>

--- a/src/shared/assets/icons/ic-chevron-right-blue.svg
+++ b/src/shared/assets/icons/ic-chevron-right-blue.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path d="M9 6L15 12L9 18" stroke="#4b7997" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #355 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 모바일 환경에서 숨김 처리해놨던 카테고리 전체보기 버튼을 항상 노출로 변경
- 오른쪽 방향 아이콘 사이즈 제어를 위해 svg 파일 수정

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<img width="399" height="111" alt="스크린샷 2026-05-18 00 06 29" src="https://github.com/user-attachments/assets/23649bb7-9e1b-4807-acde-8f0d75c46145" />

제 컴퓨터에서는 이 부분이 가운데 정렬이 안돼서 확인 부탁드려용...ㅎㅎ