### PR TITLE
[🚨 QA/#358] 이미지 연속 업로드 시 첫 번째 파일이 중복 등록되는 버그 수정

### DIFF
--- a/src/features/my-page/activity-form/common/ui/ActivityForm.tsx
+++ b/src/features/my-page/activity-form/common/ui/ActivityForm.tsx
@@ -159,10 +159,10 @@ export default function ActivityForm({
                 images={field.value ? [field.value] : []}
                 maxCount={1}
                 errorMessage={errors.bannerImage?.message}
-                onChange={(e) => {
-                  const file = e.target.files?.[0];
-                  if (file) field.onChange(file);
-                  e.target.value = '';
+                onAddFiles={(files) => {
+                  if (files.length > 0) {
+                    field.onChange(files[0]);
+                  }
                 }}
                 onRemove={() => field.onChange(null)}
               />
@@ -184,12 +184,8 @@ export default function ActivityForm({
                   images={currentImages}
                   maxCount={4}
                   errorMessage={errors.subImages?.message}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file && currentImages.length < 4) {
-                      field.onChange([...currentImages, file]);
-                    }
-                    e.target.value = '';
+                  onAddFiles={(files) => {
+                    field.onChange([...currentImages, ...files]);
                   }}
                   onRemove={(index) => {
                     const newImages = [...currentImages];

--- a/src/features/my-page/activity-form/common/ui/image-uploader/ImageUploader.stories.tsx
+++ b/src/features/my-page/activity-form/common/ui/image-uploader/ImageUploader.stories.tsx
@@ -35,18 +35,11 @@ type Story = StoryObj<typeof ImageUploader>;
 const InteractiveTemplate = (args: React.ComponentProps<typeof ImageUploader>) => {
   const [images, setImages] = useState<(File | string)[]>([]);
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files) return;
-
-    const newFiles = Array.from(files);
-
+  const handleAddFiles = (files: File[]) => {
     setImages((prev) => {
-      const combined = [...prev, ...newFiles];
+      const combined = [...prev, ...files];
       return combined.slice(0, args.maxCount ?? 1);
     });
-
-    e.target.value = '';
   };
 
   const handleImageRemove = (index: number) => {
@@ -58,7 +51,7 @@ const InteractiveTemplate = (args: React.ComponentProps<typeof ImageUploader>) =
       <ImageUploader
         {...args}
         images={images}
-        onChange={handleImageChange}
+        onAddFiles={handleAddFiles}
         onRemove={handleImageRemove}
       />
     </div>

--- a/src/features/my-page/activity-form/common/ui/image-uploader/ImageUploader.tsx
+++ b/src/features/my-page/activity-form/common/ui/image-uploader/ImageUploader.tsx
@@ -67,25 +67,27 @@ export default function ImageUploader({
   const { showToast } = useToastStore();
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    let file = e.target.files?.[0];
+    // 이벤트가 터지자마자 현재의 타겟을 변수에 묶어둠
+    const target = e.target;
+
+    let file = target.files?.[0];
     if (!file) return;
 
     try {
-      setIsConverting(true); // 로딩 시작
+      setIsConverting(true);
 
-      // 유틸 함수를 호출하여 파일 덮어쓰기
       file = await convertHeicToJpeg(file);
 
-      // 변환된 파일을 이벤트 객체에 덮어쓰기
       const dataTransfer = new DataTransfer();
       dataTransfer.items.add(file);
-      e.target.files = dataTransfer.files; // input 요소의 files 업데이트
 
-      // 유효성 검사 및 폼 상태 업데이트
+      // 지연이 발생해도 묶어둔 target 변수를 사용
+      target.files = dataTransfer.files;
+
       const validationError = validateImageFile(file);
       if (validationError) {
         setLocalError(validationError);
-        e.target.value = '';
+        target.value = '';
         return;
       }
 
@@ -94,8 +96,8 @@ export default function ImageUploader({
     } catch {
       showToast('cancel', '이미지 포맷 변환에 실패했습니다. 다른 이미지를 사용해주세요.');
     } finally {
-      setIsConverting(false); // 로딩 종료
-      e.target.value = ''; // input 초기화
+      setIsConverting(false);
+      target.value = ''; // e.target 대신 target 사용
     }
   };
 

--- a/src/features/my-page/activity-form/common/ui/image-uploader/ImageUploader.tsx
+++ b/src/features/my-page/activity-form/common/ui/image-uploader/ImageUploader.tsx
@@ -79,11 +79,7 @@ export default function ImageUploader({
       // 변환된 파일을 이벤트 객체에 덮어쓰기
       const dataTransfer = new DataTransfer();
       dataTransfer.items.add(file);
-      Object.defineProperty(e.target, 'files', {
-        value: dataTransfer.files,
-        configurable: true, // 두 번째 업로드 시에도 속성을 재정의할 수 있도록 허용
-        writable: true, // 값을 다시 쓸 수 있도록 허용
-      });
+      e.target.files = dataTransfer.files; // input 요소의 files 업데이트
 
       // 유효성 검사 및 폼 상태 업데이트
       const validationError = validateImageFile(file);

--- a/src/features/my-page/activity-form/common/ui/image-uploader/ImageUploader.tsx
+++ b/src/features/my-page/activity-form/common/ui/image-uploader/ImageUploader.tsx
@@ -16,7 +16,7 @@ export type ImageUploaderProps = {
   images: (File | string)[];
   maxCount?: number;
   showCounter?: boolean;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAddFiles: (files: File[]) => void;
   onRemove: (index: number) => void;
 };
 
@@ -33,13 +33,13 @@ const getUniqueKey = (img: File | string) => {
  * @example
  * ```tsx
  * <ImageUploader
- *   label="배너 이미지 등록"
- *   images={images}
- *   maxCount={3}
- *   showCounter={true}
- *   errorMessage={errors.bannerImage?.message}
- *   onChange={handleImageChange}
- *   onRemove={handleImageRemove}
+ * label="배너 이미지 등록"
+ * images={images}
+ * maxCount={3}
+ * showCounter={true}
+ * errorMessage={errors.bannerImage?.message}
+ * onAddFiles={handleAddFiles}
+ * onRemove={handleImageRemove}
  * />
  * ```
  */
@@ -49,7 +49,7 @@ export default function ImageUploader({
   images = [],
   maxCount = 1,
   showCounter = false,
-  onChange,
+  onAddFiles,
   onRemove,
 }: ImageUploaderProps) {
   // 컴포넌트 내부에서 즉시 유효성 검사 에러를 띄워줄 상태
@@ -69,35 +69,66 @@ export default function ImageUploader({
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     // 이벤트가 터지자마자 현재의 타겟을 변수에 묶어둠
     const target = e.target;
+    const pickedFiles = Array.from(target.files ?? []);
 
-    let file = target.files?.[0];
-    if (!file) return;
+    if (pickedFiles.length === 0) return;
+
+    // 남은 슬롯만큼만 파일 자르기
+    const remainingCount = Math.max(0, maxCount - count);
+    const filesToProcess = pickedFiles.slice(0, remainingCount);
+
+    if (filesToProcess.length === 0) {
+      target.value = '';
+      return;
+    }
+
+    setIsConverting(true);
 
     try {
-      setIsConverting(true);
+      // Promise.all을 사용하여 다중 파일의 HEIC 변환 및 유효성 검사를 병렬 처리
+      const processedResults = await Promise.all(
+        filesToProcess.map(async (file) => {
+          try {
+            const convertedFile = await convertHeicToJpeg(file);
+            const validationError = validateImageFile(convertedFile);
 
-      file = await convertHeicToJpeg(file);
+            if (validationError) {
+              return { file: null, error: validationError };
+            }
+            return { file: convertedFile, error: null };
+          } catch {
+            return {
+              file: null,
+              error: '이미지 포맷 변환에 실패했습니다. 다른 이미지를 사용해주세요.',
+            };
+          }
+        })
+      );
 
-      const dataTransfer = new DataTransfer();
-      dataTransfer.items.add(file);
+      const validFiles = processedResults
+        .filter((result) => result.file !== null)
+        .map((result) => result.file as File);
 
-      // 지연이 발생해도 묶어둔 target 변수를 사용
-      target.files = dataTransfer.files;
+      const firstError = processedResults.find((result) => result.error !== null)?.error;
 
-      const validationError = validateImageFile(file);
-      if (validationError) {
-        setLocalError(validationError);
-        target.value = '';
-        return;
+      // 에러가 하나라도 발생했다면 첫 번째 에러 메시지를 표시
+      if (firstError) {
+        setLocalError(firstError);
+        // 포맷 변환 실패 에러인 경우 Toast 알림도 함께 표시
+        if (firstError.includes('변환에 실패')) {
+          showToast('cancel', firstError);
+        }
+      } else {
+        setLocalError('');
       }
 
-      setLocalError('');
-      onChange(e);
-    } catch {
-      showToast('cancel', '이미지 포맷 변환에 실패했습니다. 다른 이미지를 사용해주세요.');
+      // 유효한 파일이 하나라도 있다면 onAddFiles 호출
+      if (validFiles.length > 0) {
+        onAddFiles(validFiles);
+      }
     } finally {
       setIsConverting(false);
-      target.value = ''; // e.target 대신 target 사용
+      target.value = ''; // 지연이 발생해도 미리 묶어둔 target 변수를 사용하여 초기화
     }
   };
 
@@ -146,6 +177,7 @@ export default function ImageUploader({
             type="file"
             className="sr-only"
             accept={IMAGE_RULES.ACCEPTED_TYPES.join(',')}
+            multiple={maxCount > 1}
             disabled={isDisabled}
             onChange={handleFileChange}
           />


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #358 

## 체크 사항

- [ ] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

속성을 강제로 재정의하는 `Object.defineProperty`를 제거하고 네이티브 할당 방식으로 교체

### 스크린샷 (선택)

<img width="506" height="263" alt="image" src="https://github.com/user-attachments/assets/a9cab11f-33d1-4cfc-b6fa-0057bf7431e1" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
