### PR TITLE
[🚨 QA/#361] 체험 수정 후 체험 카드 캐시 무효화

### DIFF
--- a/src/features/my-page/activity-form/edit/hooks/useActivityEditSubmit.ts
+++ b/src/features/my-page/activity-form/edit/hooks/useActivityEditSubmit.ts
@@ -103,6 +103,7 @@ export const useActivityEditSubmit = (activityId: number, originalData?: Activit
       showToast('check', '체험 수정이 완료되었습니다.');
       // 캐시 무효화를 통해 최신 데이터 갱신 보장
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.ACTIVITY_DETAIL(activityId) });
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.MY_ACTIVITIES_BASE() });
       router.push(`/activity/${activityId}`);
     } catch {
       showToast('cancel', '체험 수정에 실패했습니다. 다시 시도해주세요.');

--- a/src/features/my-page/activity-form/edit/hooks/useActivityEditSubmit.ts
+++ b/src/features/my-page/activity-form/edit/hooks/useActivityEditSubmit.ts
@@ -102,8 +102,11 @@ export const useActivityEditSubmit = (activityId: number, originalData?: Activit
 
       showToast('check', '체험 수정이 완료되었습니다.');
       // 캐시 무효화를 통해 최신 데이터 갱신 보장
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.ACTIVITY_DETAIL(activityId) });
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.MY_ACTIVITIES_BASE() });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.ACTIVITY_DETAIL(activityId) }),
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.MY_ACTIVITIES_BASE() }),
+        queryClient.invalidateQueries({ queryKey: ['activities'] }),
+      ]);
       router.push(`/activity/${activityId}`);
     } catch {
       showToast('cancel', '체험 수정에 실패했습니다. 다시 시도해주세요.');


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #361

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 체험 수정 성공 후 “내 체험 관리” 목록이 stale 상태로 남아 즉시 반영되지 않는 문제 수정
- 수정 성공 시 MY_ACTIVITIES_BASE 쿼리를 추가로 invalidate하여 내 체험 목록(무한스크롤 포함)이 최신 데이터로 재조회되도록 처리

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
