### PR TITLE
[🚨 QA/#363] 로그아웃/만료 시 인증 관련 캐시 초기화 및 queryKey userId 제거

### DIFF
--- a/src/features/my-page/common/mutations/useDeleteActivity.ts
+++ b/src/features/my-page/common/mutations/useDeleteActivity.ts
@@ -10,7 +10,9 @@ export const useDeleteActivity = () => {
   return useMutation({
     mutationFn: (activityId: number) => deleteActivity(activityId),
     onMutate: async (activityId) => {
-      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.MY_ACTIVITIES_INFINITE_BASE() });
+      await queryClient.cancelQueries({
+        queryKey: QUERY_KEYS.MY_ACTIVITIES_INFINITE_BASE(),
+      });
 
       const previousQueries = queryClient.getQueriesData<
         InfiniteData<GetMyActivitiesResponse, number | undefined>
@@ -39,7 +41,9 @@ export const useDeleteActivity = () => {
       });
     },
     onSettled: (_data, _error, activityId) => {
-      queryClient.removeQueries({ queryKey: [...QUERY_KEYS.MY_ACTIVITIES_BASE(), activityId] });
+      queryClient.removeQueries({
+        queryKey: [...QUERY_KEYS.MY_ACTIVITIES_BASE(), activityId],
+      });
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.MY_ACTIVITIES_BASE() });
     },
   });

--- a/src/features/notification/mutations/useDeleteAllMyNotifications.ts
+++ b/src/features/notification/mutations/useDeleteAllMyNotifications.ts
@@ -24,7 +24,7 @@ export const useDeleteAllMyNotifications = () => {
       if (ids.length === 0) return;
       if (!userId) return;
 
-      const myNotificationsQueryKey = QUERY_KEYS.MY_NOTIFICATIONS_BASE(userId);
+      const myNotificationsQueryKey = QUERY_KEYS.MY_NOTIFICATIONS_BASE();
 
       onStart?.();
 

--- a/src/features/notification/mutations/useDeleteMyNotificationMutation.ts
+++ b/src/features/notification/mutations/useDeleteMyNotificationMutation.ts
@@ -8,7 +8,7 @@ import { useUserStore } from '@/shared/stores/userStore';
 export const useDeleteMyNotificationMutation = () => {
   const queryClient = useQueryClient();
   const userId = useUserStore((s) => s.user?.id);
-  const myNotificationsQueryKey = QUERY_KEYS.MY_NOTIFICATIONS_BASE(userId);
+  const myNotificationsQueryKey = QUERY_KEYS.MY_NOTIFICATIONS_BASE();
 
   return useMutation({
     mutationFn: deleteMyNotification,

--- a/src/features/notification/mutations/useMarkMyNotificationsSeenMutation.ts
+++ b/src/features/notification/mutations/useMarkMyNotificationsSeenMutation.ts
@@ -15,7 +15,7 @@ export const useMarkMyNotificationsSeenMutation = () => {
       if (!userId) return;
       const now = Date.now();
       queryClient.setQueriesData<InfiniteData<GetMyNotificationsParsedResponse>>(
-        { queryKey: QUERY_KEYS.MY_NOTIFICATIONS_BASE(userId) },
+        { queryKey: QUERY_KEYS.MY_NOTIFICATIONS_BASE() },
         (old) => {
           if (!old) return old;
           return {

--- a/src/features/notification/queries/useMyNotifications.ts
+++ b/src/features/notification/queries/useMyNotifications.ts
@@ -28,7 +28,7 @@ export const useMyNotifications = ({ size = MY_NOTIFICATIONS_PAGE_SIZE } = {}) =
     QueryKey,
     number | undefined
   >({
-    queryKey: QUERY_KEYS.MY_NOTIFICATIONS(userId, size),
+    queryKey: QUERY_KEYS.MY_NOTIFICATIONS(size),
     enabled: !!userId,
     initialPageParam: undefined,
     queryFn: async ({ pageParam }) =>

--- a/src/shared/constants/queryKey.ts
+++ b/src/shared/constants/queryKey.ts
@@ -23,11 +23,11 @@ export const QUERY_KEYS = {
   MY_RESERVATIONS: (status?: string, size?: number) =>
     ['my-reservations', status ?? 'all', size ?? 'default'] as const,
   /** 내 알림 조회 - prefix */
-  MY_NOTIFICATIONS_BASE: (userId?: number) => ['my-notifications', userId ?? 'anonymous'] as const,
+  MY_NOTIFICATIONS_BASE: () => ['my-notifications'] as const,
 
   /** 내 알림 조회 */
-  MY_NOTIFICATIONS: (userId?: number, size?: number) =>
-    [...QUERY_KEYS.MY_NOTIFICATIONS_BASE(userId), size ?? 'default'] as const,
+  MY_NOTIFICATIONS: (size?: number) =>
+    [...QUERY_KEYS.MY_NOTIFICATIONS_BASE(), size ?? 'default'] as const,
 
   /** 내 체험 목록 조회 - prefix */
   MY_ACTIVITIES_BASE: () => ['my-activities'] as const,

--- a/src/shared/constants/queryKey.ts
+++ b/src/shared/constants/queryKey.ts
@@ -19,9 +19,11 @@ export const QUERY_KEYS = {
   ACTIVITY_LIST: (params: GetActivityParams) => ['activities', params] as const,
   /** 로그인한 사용자 정보 조회 */
   USER_ME: () => ['users', 'me'] as const,
+  /** 내 예약 내역 조회 - prefix */
+  MY_RESERVATIONS_BASE: () => ['my-reservations'] as const,
   /** 내 예약 내역 조회 */
   MY_RESERVATIONS: (status?: string, size?: number) =>
-    ['my-reservations', status ?? 'all', size ?? 'default'] as const,
+    [...QUERY_KEYS.MY_RESERVATIONS_BASE(), status ?? 'all', size ?? 'default'] as const,
   /** 내 알림 조회 - prefix */
   MY_NOTIFICATIONS_BASE: () => ['my-notifications'] as const,
 

--- a/src/shared/stores/userStore.ts
+++ b/src/shared/stores/userStore.ts
@@ -1,6 +1,18 @@
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 import { UserResponse } from '@/features/user/types';
+import { getQueryClient } from '@/shared/utils/getQueryClient';
+
+const clearAuthRelatedQueryCache = () => {
+  if (typeof window === 'undefined') return;
+  const queryClient = getQueryClient();
+
+  // NOTE: 계정 전환/로그아웃 시 이전 사용자 데이터가 화면에 남지 않도록 관련 캐시를 제거합니다.
+  queryClient.removeQueries({ queryKey: ['users', 'me'] });
+  queryClient.removeQueries({ queryKey: ['my-activities'] });
+  queryClient.removeQueries({ queryKey: ['my-reservations'] });
+  queryClient.removeQueries({ queryKey: ['my-notifications'] });
+};
 
 /**
  * ## SessionEndReason
@@ -93,7 +105,8 @@ export const useUserStore = create<
             false,
             'user/setSession'
           ),
-        clearSession: (reason) =>
+        clearSession: (reason) => {
+          clearAuthRelatedQueryCache();
           set(
             {
               user: undefined,
@@ -102,7 +115,8 @@ export const useUserStore = create<
             },
             false,
             'user/clearSession'
-          ),
+          );
+        },
         setHasHydrated: (hasHydrated) => set({ hasHydrated }, false, 'user/setHasHydrated'),
       }),
       {

--- a/src/shared/stores/userStore.ts
+++ b/src/shared/stores/userStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 import { UserResponse } from '@/features/user/types';
+import { QUERY_KEYS } from '@/shared/constants/queryKey';
 import { getQueryClient } from '@/shared/utils/getQueryClient';
 
 const clearAuthRelatedQueryCache = () => {
@@ -8,10 +9,10 @@ const clearAuthRelatedQueryCache = () => {
   const queryClient = getQueryClient();
 
   // NOTE: 계정 전환/로그아웃 시 이전 사용자 데이터가 화면에 남지 않도록 관련 캐시를 제거합니다.
-  queryClient.removeQueries({ queryKey: ['users', 'me'] });
-  queryClient.removeQueries({ queryKey: ['my-activities'] });
-  queryClient.removeQueries({ queryKey: ['my-reservations'] });
-  queryClient.removeQueries({ queryKey: ['my-notifications'] });
+  queryClient.removeQueries({ queryKey: QUERY_KEYS.USER_ME() });
+  queryClient.removeQueries({ queryKey: QUERY_KEYS.MY_ACTIVITIES_BASE() });
+  queryClient.removeQueries({ queryKey: QUERY_KEYS.MY_RESERVATIONS_BASE() });
+  queryClient.removeQueries({ queryKey: QUERY_KEYS.MY_NOTIFICATIONS_BASE() });
 };
 
 /**


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #363

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- React Query queryKey에서 userId를 제거해 계정 전환 시 불필요한 리렌더/재요청을 방지
- 로그아웃/세션 만료 시 clearSession()에서 인증 관련 쿼리 캐시(users/me, my-activities, my-reservations, my-notifications)를 제거하도록 처리해 이전 계정 데이터 잔존 문제 해결
- 알림 기능(my-notifications)도 userId 없는 queryKey로 통일하고 관련 쿼리/뮤테이션 키 참조를 정리

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
