### PR TITLE
[🚨 QA/#369] 예약 종료 시간 23:59를 24:00으로 표시되도록 수정

### DIFF
--- a/src/features/reservation/activity-panel/ui/ScheduleList.tsx
+++ b/src/features/reservation/activity-panel/ui/ScheduleList.tsx
@@ -4,6 +4,7 @@ import { ActivityScheduleTime } from '@/features/activity/types';
 import Button from '@/shared/ui/button/Button';
 import Loading from '@/shared/ui/loading/Loading';
 import { cn } from '@/shared/utils/cn';
+import { formatEndTime } from '@/shared/utils/time';
 
 type ScheduleListProps = {
   selected?: Date;
@@ -113,7 +114,7 @@ export default function ScheduleList({
                     : 'border-gray-300 text-gray-950'
               )}
             >
-              {schedule.startTime}~{schedule.endTime}
+              {schedule.startTime}~{formatEndTime(schedule.endTime)}
             </button>
           );
         })}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #369 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

체험 상세 페이지 예약 가능한 시간 목록에서 종료 시간이 23:59로 표시되는 문제를 수정했습니다.
- `formatEndTime` 유틸 함수를 적용해 23:59를 24:00으로 변환하여 표시

### 스크린샷 (선택)
<img width="377" height="251" alt="image" src="https://github.com/user-attachments/assets/8cbff7fd-078a-431b-82be-57b28003cc0e" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
