### PR TITLE
[🚨QA/#372] 체험 상세 페이지 및 토스트 아이콘 크기 명시

### DIFF
--- a/src/features/activity/activity-detail/ui/activity-info/ActivityAddress.tsx
+++ b/src/features/activity/activity-detail/ui/activity-info/ActivityAddress.tsx
@@ -9,7 +9,7 @@ type ActivityAddressProps = {
 export default function ActivityAddress({ address, className }: ActivityAddressProps) {
   return (
     <div className={cn('flex items-center gap-1', className)}>
-      <LocationIcon aria-hidden />
+      <LocationIcon aria-hidden className="h-4 w-4" />
       <p className="typo-14-medium text-gray-700">{address}</p>
     </div>
   );

--- a/src/features/activity/activity-detail/ui/activity-info/ActivityInfo.tsx
+++ b/src/features/activity/activity-detail/ui/activity-info/ActivityInfo.tsx
@@ -1,7 +1,7 @@
 import ActivityAddress from '@/features/activity/activity-detail/ui/activity-info/ActivityAddress';
 import ActivityKebabMenu from '@/features/activity/activity-detail/ui/activity-info/ActivityKebabMenu';
 import ActivityShare from '@/features/activity/activity-detail/ui/share/ActivityShare';
-import { StarIcon } from '@/shared/assets/icons';
+import RatingSummary from '@/shared/ui/rating-summary/RatingSummary';
 import Title from '@/shared/ui/title/Title';
 import { cn } from '@/shared/utils/cn';
 
@@ -63,14 +63,8 @@ export default function ActivityInfo({
         {title}
       </Title>
       {/* 별점 */}
-      <div className="mb-2.5 flex items-center gap-1.5">
-        <StarIcon aria-hidden className="text-yellow-500" />
-        <span
-          className="typo-14-medium text-gray-700"
-          aria-label={`별점 ${rating}점, 리뷰 ${reviewCount}개`}
-        >
-          {rating} ({reviewCount})
-        </span>
+      <div className="mb-2.5">
+        <RatingSummary averageRating={rating} totalCount={reviewCount} />
       </div>
       {/* 주소, 공유 기능 */}
       <div className="flex items-center justify-between">

--- a/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
+++ b/src/features/activity/activity-detail/ui/share/ActivityShare.tsx
@@ -31,7 +31,7 @@ export default function ActivityShare({ title, description, bannerImageUrl }: Ac
   return (
     <div className="flex items-center gap-3">
       <button type="button" onClick={handleCopyUrl} aria-label="URL 복사">
-        <LinkIcon />
+        <LinkIcon className="h-6 w-6" />
       </button>
       <button
         type="button"
@@ -39,7 +39,7 @@ export default function ActivityShare({ title, description, bannerImageUrl }: Ac
         aria-label="카카오톡 공유"
         className="flex h-9 w-9 items-center justify-center rounded-full bg-kakao-bg"
       >
-        <KakaoIcon />
+        <KakaoIcon className="h-6 w-6" />
       </button>
     </div>
   );

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -14,10 +14,10 @@ type ToastProps = {
 };
 
 const toastIconConfig = {
-  cancel: { icon: <CancelIcon /> },
-  check: { icon: <CheckIcon /> },
-  warning: { icon: <WarningIcon /> },
-  info: { icon: <NoticeIcon /> },
+  cancel: { icon: <CancelIcon className="h-7 w-7" /> },
+  check: { icon: <CheckIcon className="h-7 w-7" /> },
+  warning: { icon: <WarningIcon className="h-7 w-7" /> },
+  info: { icon: <NoticeIcon className="h-7 w-7" /> },
 };
 
 /**


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #372 

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

SVG 최적화 PR 반영 후 width/height 속성이 제거되어 체험 상세 페이지 아이콘들이 비정상적으로 크게 표시되는 문제를 수정했습니다.
- `ActivityInfo` - RatingSummary 공통 컴포넌트로 교체
- `ActivityAddress` - LocationIcon 크기 명시
- `ActivityShare` - LinkIcon, KakaoIcon 크기 명시
- `Toast` - CancelIcon, CheckIcon, WarningIcon, NoticeIcon 크기 명시

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
