### PR TITLE
[🚨QA/#379] 로그인/회원가입 및 메인 페이지 아이콘 사이즈 지정

### DIFF
--- a/src/app/(public)/(auth)/ui/SpeechBubble.tsx
+++ b/src/app/(public)/(auth)/ui/SpeechBubble.tsx
@@ -11,10 +11,8 @@ type SpeechBubbleProps = React.HTMLAttributes<HTMLDivElement> & {
  */
 export default function SpeechBubble({ isFlipped, className, children }: SpeechBubbleProps) {
   return (
-    <div className={cn('relative w-full', isFlipped && '-scale-x-100', className)}>
-      <div className="h-32.5 w-77.5">
-        <SpeechBubbleImage />
-      </div>
+    <div className={cn('relative h-32.5 w-77.5', isFlipped && '-scale-x-100', className)}>
+      <SpeechBubbleImage />
       <p
         className={cn(
           'absolute inset-0 z-10 flex translate-y-8.25 justify-center typo-18-medium text-gray-900',

--- a/src/app/(public)/(auth)/ui/SpeechBubble.tsx
+++ b/src/app/(public)/(auth)/ui/SpeechBubble.tsx
@@ -12,7 +12,7 @@ type SpeechBubbleProps = React.HTMLAttributes<HTMLDivElement> & {
 export default function SpeechBubble({ isFlipped, className, children }: SpeechBubbleProps) {
   return (
     <div className={cn('relative w-full', isFlipped && '-scale-x-100', className)}>
-      <div className="w-77.5">
+      <div className="h-32.5 w-77.5">
         <SpeechBubbleImage />
       </div>
       <p

--- a/src/app/(public)/(auth)/ui/SpeechBubble.tsx
+++ b/src/app/(public)/(auth)/ui/SpeechBubble.tsx
@@ -11,8 +11,10 @@ type SpeechBubbleProps = React.HTMLAttributes<HTMLDivElement> & {
  */
 export default function SpeechBubble({ isFlipped, className, children }: SpeechBubbleProps) {
   return (
-    <div className={cn('relative', isFlipped && '-scale-x-100', className)}>
-      <SpeechBubbleImage />
+    <div className={cn('relative w-full', isFlipped && '-scale-x-100', className)}>
+      <div className="w-77.5">
+        <SpeechBubbleImage />
+      </div>
       <p
         className={cn(
           'absolute inset-0 z-10 flex translate-y-8.25 justify-center typo-18-medium text-gray-900',

--- a/src/features/activity/main/ui/MainActivityList.tsx
+++ b/src/features/activity/main/ui/MainActivityList.tsx
@@ -80,7 +80,9 @@ export default function MainActivityList() {
             disabled={!canScrollPrev}
             ariaLabel="이전"
           >
-            <ArrowLeftIcon />
+            <span className="h-6 w-6">
+              <ArrowLeftIcon />
+            </span>
           </CarouselArrowButton>
 
           {/* 이미지 캐러셀 */}
@@ -108,7 +110,9 @@ export default function MainActivityList() {
             className="-right-5"
             ariaLabel="다음"
           >
-            <ArrowRightIcon />
+            <span className="h-6 w-6">
+              <ArrowRightIcon />
+            </span>
           </CarouselArrowButton>
         </div>
       )}

--- a/src/features/activity/main/ui/MainActivityList.tsx
+++ b/src/features/activity/main/ui/MainActivityList.tsx
@@ -80,9 +80,7 @@ export default function MainActivityList() {
             disabled={!canScrollPrev}
             ariaLabel="이전"
           >
-            <span className="h-6 w-6">
-              <ArrowLeftIcon />
-            </span>
+            <ArrowLeftIcon className="h-6 w-6" />
           </CarouselArrowButton>
 
           {/* 이미지 캐러셀 */}
@@ -110,9 +108,7 @@ export default function MainActivityList() {
             className="-right-5"
             ariaLabel="다음"
           >
-            <span className="h-6 w-6">
-              <ArrowRightIcon />
-            </span>
+            <ArrowRightIcon className="h-6 w-6" />
           </CarouselArrowButton>
         </div>
       )}

--- a/src/features/auth/ui/KakaoAuthButton.tsx
+++ b/src/features/auth/ui/KakaoAuthButton.tsx
@@ -23,9 +23,7 @@ export default function KakaoAuthButton({ mode, className, ...props }: KakaoAuth
       {...props}
     >
       <span className="flex gap-1.5">
-        <span className="w-6">
-          <KakaoIcon />
-        </span>
+        <KakaoIcon className="h-6 w-6" />
         <span className="typo-16-medium">카카오 {label}</span>
       </span>
     </a>

--- a/src/features/auth/ui/KakaoAuthButton.tsx
+++ b/src/features/auth/ui/KakaoAuthButton.tsx
@@ -23,7 +23,9 @@ export default function KakaoAuthButton({ mode, className, ...props }: KakaoAuth
       {...props}
     >
       <span className="flex gap-1.5">
-        <KakaoIcon />
+        <span className="w-6">
+          <KakaoIcon />
+        </span>
         <span className="typo-16-medium">카카오 {label}</span>
       </span>
     </a>

--- a/src/shared/ui/input/PasswordInput.tsx
+++ b/src/shared/ui/input/PasswordInput.tsx
@@ -33,7 +33,7 @@ export default function PasswordInput<T extends FieldValues>({
           type="button"
           onClick={() => setShowPassword((prev) => !prev)}
           aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-          className="flex items-center justify-center text-gray-400 transition-colors hover:text-gray-600"
+          className="flex h-6 w-6 items-center justify-center text-gray-400 transition-colors hover:text-gray-600"
         >
           {showPassword ? <EyeOnIcon /> : <EyeOffIcon />}
         </button>

--- a/src/shared/ui/input/PasswordInput.tsx
+++ b/src/shared/ui/input/PasswordInput.tsx
@@ -33,9 +33,9 @@ export default function PasswordInput<T extends FieldValues>({
           type="button"
           onClick={() => setShowPassword((prev) => !prev)}
           aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-          className="flex h-6 w-6 items-center justify-center text-gray-400 transition-colors hover:text-gray-600"
+          className="flex items-center justify-center text-gray-400 transition-colors hover:text-gray-600"
         >
-          {showPassword ? <EyeOnIcon /> : <EyeOffIcon />}
+          {showPassword ? <EyeOnIcon className="h-6 w-6" /> : <EyeOffIcon className="h-6 w-6" />}
         </button>
       }
     />


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #379

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

SVG 최적화 후 사이즈를 지정하지 않았던 아이콘들의 사이즈 이슈를 해결했습니다.

### 로그인/회원가입
- 카카오 아이콘
- 말풍선 아이콘
- 비밀번호 인풋 눈 모양 아이콘 

### 메인페이지
- 인기 체험 슬라이드 화살표 아이콘

### 스크린샷 (선택)
<img width="1257" height="737" alt="스크린샷 2026-05-18 16 08 13" src="https://github.com/user-attachments/assets/0d865d75-f0a4-4c65-9cc5-b16aafcd3929" />
<img width="1192" height="521" alt="스크린샷 2026-05-18 16 08 23" src="https://github.com/user-attachments/assets/0b7d40c9-eea9-46f4-b2ef-6bceab76cf1d" />

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
