### PR TITLE
[🚨 QA/#389] 이미지 업로드 용량 최대 4MB 하향 조정

### DIFF
--- a/src/shared/constants/file.ts
+++ b/src/shared/constants/file.ts
@@ -2,7 +2,7 @@
  * 이미지 업로드 관련 설정 상수입니다.
  */
 export const IMAGE_RULES = {
-  MAX_SIZE: 5 * 1024 * 1024, // 5MB
+  MAX_SIZE: 4 * 1024 * 1024, // 4MB
   ACCEPTED_TYPES: [
     'image/jpeg',
     'image/jpg',
@@ -17,6 +17,6 @@ export const IMAGE_RULES = {
  * 이미지 업로드 관련 에러 메시지입니다.
  */
 export const IMAGE_ERROR_MESSAGES = {
-  IMAGE_SIZE_EXCEEDED: '이미지 용량은 5MB를 초과할 수 없습니다',
+  IMAGE_SIZE_EXCEEDED: '이미지 용량은 4MB를 초과할 수 없습니다',
   IMAGE_TYPE_INVALID: 'JPG, JPEG, PNG, WEBP, HEIC, HEIF 파일만 업로드 가능합니다',
 } as const;

--- a/src/shared/constants/file.ts
+++ b/src/shared/constants/file.ts
@@ -17,6 +17,6 @@ export const IMAGE_RULES = {
  * 이미지 업로드 관련 에러 메시지입니다.
  */
 export const IMAGE_ERROR_MESSAGES = {
-  IMAGE_SIZE_EXCEEDED: '이미지 용량은 4MB를 초과할 수 없습니다',
+  IMAGE_SIZE_EXCEEDED: `이미지 용량은 ${IMAGE_RULES.MAX_SIZE / (1024 * 1024)}MB를 초과할 수 없습니다`,
   IMAGE_TYPE_INVALID: 'JPG, JPEG, PNG, WEBP, HEIC, HEIF 파일만 업로드 가능합니다',
 } as const;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #389 

## 체크 사항

- [] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이미지 업로드 상수 변경
- `IMAGE_RULES.MAX_SIZE` 단위를 `4 * 1024 * 1024` (4MB)로 하향 조정
- 에러 메시지도 `이미지 용량은 4MB를 초과할 수 없습니다`로 동기화

윈도우는 2진법으로 계산해서 화면에 표시된 4MB가 내부 검사 기준과 일치하지만, 맥북은 10진법을 사용하기 때문에 화면에 표시된 용량과 실제 코드에서 계산하는 용량 간에 오차가 발생함. 테스트 결과 macOS에서 '4.2MB'로 표기된 파일 -> 실제 계산된 크기 '4.02MB'이였으며, 이 파일이 유효성 검사를 통과하는 걸 확인하고 업로드 최대 허용 용량을 4MB로 하향 조정하여, OS 환경에 상관없이 의도한 용량 제한이 정확히 작동하도록 수정함.

### 스크린샷 (선택)

<img width="212" height="189" alt="image" src="https://github.com/user-attachments/assets/24efe45f-ab13-4775-8c5e-38a77d69179a" />
<img width="477" height="440" alt="image" src="https://github.com/user-attachments/assets/a0c0f0c1-c585-41d1-8e44-0aeb3760ad50" />
<img width="453" height="24" alt="image" src="https://github.com/user-attachments/assets/f02f4b90-16de-4b52-986a-7ebe26987ff6" />


### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
