### PR TITLE
[♻️ Refactor/#394] network, http 에러 분리

### DIFF
--- a/src/app/(public)/(explore)/activity/[id]/page.tsx
+++ b/src/app/(public)/(explore)/activity/[id]/page.tsx
@@ -6,7 +6,7 @@ import { getActivityDetail, getActivityReviews } from '@/features/activity/apis'
 import ReservationBar from '@/features/reservation/activity-panel/ui/ReservationBar';
 import ReservationWidget from '@/features/reservation/activity-panel/ui/ReservationWidget';
 import { getAvailableSchedule } from '@/features/reservation/apis';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { COMMON_OPEN_GRAPH } from '@/shared/constants/metadata';
 
 type Props = {
@@ -64,7 +64,7 @@ export default async function ActivityDetailPage({ params }: Props) {
   // 체험 상세 정보 불러오기 실패 시 404 또는 에러 처리
   if (detailResult.status === 'rejected') {
     const error = detailResult.reason;
-    if (error instanceof ApiError && error.status === 404) notFound();
+    if (error instanceof HttpError && error.status === 404) notFound();
     throw error;
   }
 

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -3,7 +3,7 @@ import type {
   CreateActivityRequestBody,
   CreateActivityResponse,
 } from '@/features/my-page/activity-form/types';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
 import { proxyFetch } from '@/shared/apis/bff/proxy';
 
@@ -19,7 +19,7 @@ import { proxyFetch } from '@/shared/apis/bff/proxy';
  */
 export const POST = createAuthorizedRoute<CreateActivityRequestBody>(async ({ body }) => {
   if (body?.title && body.title.length > 50) {
-    throw new ApiError(400, ACTIVITY_ERROR_MESSAGES.TITLE_MAX_LENGTH);
+    throw new HttpError(400, ACTIVITY_ERROR_MESSAGES.TITLE_MAX_LENGTH);
   }
   return proxyFetch.post<CreateActivityResponse>('/activities', body);
 });

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,7 +4,7 @@ import { LoginResponse } from '@/features/auth/types/auth';
 import { setAuthCookies, setLoginMethodCookie } from '@/features/auth/utils/cookies';
 import { getJwtExpiresAt } from '@/features/auth/utils/jwt';
 import { LoginFormValues } from '@/features/auth/utils/schema';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { serverFetch } from '@/shared/apis/base/serverFetch';
 
 /**
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
 
     return response;
   } catch (error) {
-    if (error instanceof ApiError) {
+    if (error instanceof HttpError) {
       return NextResponse.json(
         { message: error.message || AUTH_API_MESSAGE.LOGIN.ERROR },
         { status: error.status }

--- a/src/app/api/auth/tokens/route.ts
+++ b/src/app/api/auth/tokens/route.ts
@@ -3,7 +3,7 @@ import { AUTH_API_MESSAGE } from '@/features/auth/constants/authMessage';
 import { RefreshResponse } from '@/features/auth/types/auth';
 import { getAuthCookie, setAuthCookies } from '@/features/auth/utils/cookies';
 import { getJwtExpiresAt } from '@/features/auth/utils/jwt';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { serverFetch } from '@/shared/apis/base/serverFetch';
 
 /**
@@ -48,7 +48,7 @@ export async function POST() {
     return response;
   } catch (error) {
     // 서버 또는 네트워크 에러
-    if (error instanceof ApiError) {
+    if (error instanceof HttpError) {
       return NextResponse.json(
         { message: error.message || AUTH_API_MESSAGE.LOGIN.ERROR },
         { status: error.status }

--- a/src/app/api/my-activities/[activityId]/route.ts
+++ b/src/app/api/my-activities/[activityId]/route.ts
@@ -3,7 +3,7 @@ import type {
   UpdateMyActivityRequestBody,
   UpdateMyActivityResponse,
 } from '@/features/my-page/activity-form/types';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { createAuthorizedRoute } from '@/shared/apis/bff/createAuthorizedRoute';
 import { proxyFetch } from '@/shared/apis/bff/proxy';
 import { requireParams } from '@/shared/apis/bff/requireParams';
@@ -38,7 +38,7 @@ export const PATCH = createAuthorizedRoute<UpdateMyActivityRequestBody, { activi
   async ({ params, body }) => {
     const { activityId } = requireParams(params);
     if (body?.title && body.title.length > 50) {
-      throw new ApiError(400, ACTIVITY_ERROR_MESSAGES.TITLE_MAX_LENGTH);
+      throw new HttpError(400, ACTIVITY_ERROR_MESSAGES.TITLE_MAX_LENGTH);
     }
     return proxyFetch.patch<UpdateMyActivityResponse>(`/my-activities/${activityId}`, body);
   }

--- a/src/app/api/oauth/signin/kakao/route.ts
+++ b/src/app/api/oauth/signin/kakao/route.ts
@@ -6,7 +6,7 @@ import {
   createOAuthSessionResponse,
   getRequiredKakaoRedirectUri,
 } from '@/features/auth/utils/oauthSessionServer';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { serverFetch } from '@/shared/apis/base/serverFetch';
 
 export async function POST(request: NextRequest) {
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
       refreshToken: data.refreshToken,
     });
   } catch (error) {
-    if (error instanceof ApiError) {
+    if (error instanceof HttpError) {
       return NextResponse.json({ message: error.message }, { status: error.status });
     }
     if (error instanceof Error) {

--- a/src/app/api/oauth/signup/kakao/route.ts
+++ b/src/app/api/oauth/signup/kakao/route.ts
@@ -6,7 +6,7 @@ import {
   createOAuthSessionResponse,
   getRequiredKakaoRedirectUri,
 } from '@/features/auth/utils/oauthSessionServer';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { serverFetch } from '@/shared/apis/base/serverFetch';
 
 export async function POST(request: NextRequest) {
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
       refreshToken: data.refreshToken,
     });
   } catch (error) {
-    if (error instanceof ApiError) {
+    if (error instanceof HttpError) {
       return NextResponse.json({ message: error.message }, { status: error.status });
     }
     if (error instanceof Error) {

--- a/src/app/oauth/kakao/KakaoOauthCallbackClient.tsx
+++ b/src/app/oauth/kakao/KakaoOauthCallbackClient.tsx
@@ -13,7 +13,7 @@ import {
   KAKAO_OAUTH_START_SIGNIN_URL,
   KAKAO_OAUTH_START_SIGNUP_URL,
 } from '@/features/auth/utils/kakaoOauthClient';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { useUserStore } from '@/shared/stores/userStore';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
@@ -77,7 +77,7 @@ export default function KakaoOauthCallbackClient() {
         const errorMessage = err instanceof Error ? err.message : '';
         if (
           mode === 'signin' &&
-          err instanceof ApiError &&
+          err instanceof HttpError &&
           (err.status === 404 || isNotRegisteredKakaoUserError(errorMessage))
         ) {
           window.location.replace(KAKAO_OAUTH_START_SIGNUP_URL);

--- a/src/features/auth/guards/GuestGuard.tsx
+++ b/src/features/auth/guards/GuestGuard.tsx
@@ -5,7 +5,7 @@ import type { PropsWithChildren } from 'react';
 import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { getMe } from '@/features/user/apis';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { useUserStore } from '@/shared/stores/userStore';
 
 /**
@@ -37,7 +37,7 @@ export default function GuestGuard({ children }: PropsWithChildren) {
         await getMe();
         router.replace('/');
       } catch (error) {
-        if (error instanceof ApiError && error.status === 401) {
+        if (error instanceof HttpError && error.status === 401) {
           clearSession('expired');
           return;
         }

--- a/src/features/auth/hooks/useTokenRefresh.test.tsx
+++ b/src/features/auth/hooks/useTokenRefresh.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { refreshAuthTokens } from '@/features/auth/apis/auth';
 import { useTokenRefresh } from '@/features/auth/hooks/useTokenRefresh';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { useUserStore } from '@/shared/stores/userStore';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
@@ -47,7 +47,7 @@ describe('useTokenRefresh', () => {
   });
 
   it('refresh 실패(401)이면 세션을 비우고 토스트를 띄운다', async () => {
-    mockRefreshAuthTokens.mockRejectedValueOnce(new ApiError(401, 'Unauthorized'));
+    mockRefreshAuthTokens.mockRejectedValueOnce(new HttpError(401, 'Unauthorized'));
 
     const clearSessionSpy = jest.spyOn(useUserStore.getState(), 'clearSession');
     const showToastSpy = jest.spyOn(useToastStore.getState(), 'showToast');

--- a/src/features/auth/hooks/useTokenRefresh.ts
+++ b/src/features/auth/hooks/useTokenRefresh.ts
@@ -2,7 +2,7 @@
 import * as Sentry from '@sentry/nextjs';
 import { useEffect, useRef } from 'react';
 import { refreshAuthTokens } from '@/features/auth/apis/auth';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { useUserStore } from '@/shared/stores/userStore';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
@@ -67,7 +67,7 @@ export const useTokenRefresh = () => {
           }
         }
       } catch (error) {
-        if (error instanceof ApiError && error.status === 401) {
+        if (error instanceof HttpError && error.status === 401) {
           clearSession('expired');
           showToast('warning', '로그인 시간이 만료되었습니다. 다시 로그인해 주세요.');
           return;

--- a/src/features/auth/providers/AuthSessionGuard.tsx
+++ b/src/features/auth/providers/AuthSessionGuard.tsx
@@ -4,7 +4,7 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { isProtectedPath } from '@/features/auth/utils/path';
 import { getMe } from '@/features/user/apis';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { useUserStore } from '@/shared/stores/userStore';
 
 /**
@@ -35,7 +35,7 @@ export default function AuthSessionGuard() {
       try {
         await getMe();
       } catch (error) {
-        if (error instanceof ApiError && error.status === 401) {
+        if (error instanceof HttpError && error.status === 401) {
           clearSession('expired');
           return;
         }

--- a/src/features/auth/providers/AuthSessionSync.tsx
+++ b/src/features/auth/providers/AuthSessionSync.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { getMe } from '@/features/user/apis';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { useUserStore } from '@/shared/stores/userStore';
 
 /**
@@ -39,7 +39,7 @@ export default function AuthSessionSync() {
         const me = await getMe();
         if (me) setUser(me);
       } catch (error) {
-        if (error instanceof ApiError && error.status === 401) {
+        if (error instanceof HttpError && error.status === 401) {
           clearSession('expired');
           return;
         }

--- a/src/features/auth/ui/LoginClient.tsx
+++ b/src/features/auth/ui/LoginClient.tsx
@@ -95,6 +95,7 @@ export default function LoginClient() {
             type: 'server',
             message,
           });
+          return;
         }
 
         showToast('cancel', '로그인 중 오류가 발생했습니다.');

--- a/src/features/auth/ui/LoginClient.tsx
+++ b/src/features/auth/ui/LoginClient.tsx
@@ -1,14 +1,14 @@
 'use client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { loginUser } from '@/features/auth/apis/auth';
 import { AUTH_API_MESSAGE } from '@/features/auth/constants/authMessage';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
 import { LoginFormValues, loginSchema } from '@/features/auth/utils/schema';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError, NetworkError } from '@/shared/apis/apiError';
 import { useUserStore } from '@/shared/stores/userStore';
 import Button from '@/shared/ui/button/Button';
 import FormErrorMessage from '@/shared/ui/form/FormErrorMessage';
@@ -32,6 +32,7 @@ const AUTH_CLIENT_MESSAGE = '이메일 또는 비밀번호를 확인해 주세�
 export default function LoginClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [fatalError, setFatalError] = useState<Error | null>(null);
   const setSession = useUserStore((state) => state.setSession);
   const { showToast } = useToastStore();
   const methods = useForm({
@@ -49,6 +50,10 @@ export default function LoginClient() {
     setError,
     formState: { isSubmitting, isDirty, errors },
   } = methods;
+
+  if (fatalError) {
+    throw fatalError;
+  }
 
   /** 로그인 요청 핸들러 */
   const handleLogin = useCallback(
@@ -71,7 +76,17 @@ export default function LoginClient() {
           router.push(safeRedirect);
         }
       } catch (error) {
-        if (error instanceof ApiError) {
+        if (error instanceof NetworkError) {
+          showToast('cancel', '로그인 중 오류가 발생했습니다.');
+          return;
+        }
+
+        if (error instanceof HttpError) {
+          if (error.status >= 500) {
+            setFatalError(error);
+            return;
+          }
+
           // 404는 서버 메시지, 그 외 에러는 고정 메시지 사용
           const message =
             error.status === 404 ? removeDotSuffix(error.message) : AUTH_CLIENT_MESSAGE;
@@ -80,55 +95,48 @@ export default function LoginClient() {
             type: 'server',
             message,
           });
-        } else {
-          // 네트워크 에러 등
-          showToast('cancel', '로그인 중 오류가 발생했습니다.');
         }
+
+        showToast('cancel', '로그인 중 오류가 발생했습니다.');
       }
     },
     [router, searchParams, setError, setSession, showToast]
   );
 
   return (
-    <>
-      <div className="mt-17 md:mt-22">
-        <AuthForm onSubmit={handleSubmit(handleLogin)}>
-          <FormField label="이메일" errorMessage={errors.email?.message}>
-            <FormInput
-              type="email"
-              name="email"
-              control={control}
-              placeholder="이메일을 입력해 주세요"
-            />
-          </FormField>
+    <div className="mt-17 md:mt-22">
+      <AuthForm onSubmit={handleSubmit(handleLogin)}>
+        <FormField label="이메일" errorMessage={errors.email?.message}>
+          <FormInput
+            type="email"
+            name="email"
+            control={control}
+            placeholder="이메일을 입력해 주세요"
+          />
+        </FormField>
 
-          <FormField label="비밀번호" errorMessage={errors.password?.message}>
-            <PasswordInput
-              name="password"
-              control={control}
-              placeholder="비밀번호를 입력해 주세요"
-            />
-          </FormField>
-          <div className="mt-1 md:mt-2">
-            {/* 백엔드 에러 메시지 */}
-            {errors.root && (
-              <FormErrorMessage className="typo-13-medium">{errors.root.message}</FormErrorMessage>
-            )}
+        <FormField label="비밀번호" errorMessage={errors.password?.message}>
+          <PasswordInput name="password" control={control} placeholder="비밀번호를 입력해 주세요" />
+        </FormField>
+        <div className="mt-1 md:mt-2">
+          {/* 백엔드 에러 메시지 */}
+          {errors.root && (
+            <FormErrorMessage className="typo-13-medium">{errors.root.message}</FormErrorMessage>
+          )}
 
-            <Button
-              type="submit"
-              theme="primary"
-              size="lg"
-              isLoading={isSubmitting}
-              disabled={!isDirty || isSubmitting}
-              className={cn('mt-1 h-13.5 w-full rounded-2xl', !errors.root && 'md:mt-2')}
-            >
-              로그인 하기
-            </Button>
-          </div>
-        </AuthForm>
-        <AuthFooter />
-      </div>
-    </>
+          <Button
+            type="submit"
+            theme="primary"
+            size="lg"
+            isLoading={isSubmitting}
+            disabled={!isDirty || isSubmitting}
+            className={cn('mt-1 h-13.5 w-full rounded-2xl', !errors.root && 'md:mt-2')}
+          >
+            로그인 하기
+          </Button>
+        </div>
+      </AuthForm>
+      <AuthFooter />
+    </div>
   );
 }

--- a/src/features/auth/ui/SignupClient.tsx
+++ b/src/features/auth/ui/SignupClient.tsx
@@ -1,14 +1,14 @@
 'use client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { signupUser } from '@/features/auth/apis/auth';
 import { AUTH_API_MESSAGE } from '@/features/auth/constants/authMessage';
 import AuthFooter from '@/features/auth/ui/AuthFooter';
 import AuthForm from '@/features/auth/ui/AuthForm';
 import { SignupFormValues, signupSchema } from '@/features/auth/utils/schema';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError, NetworkError } from '@/shared/apis/apiError';
 import Button from '@/shared/ui/button/Button';
 import FormErrorMessage from '@/shared/ui/form/FormErrorMessage';
 import FormField from '@/shared/ui/form/FormField';
@@ -28,6 +28,7 @@ import { removeDotSuffix } from '@/shared/utils/stringFormat';
  */
 export default function SignupClient() {
   const router = useRouter();
+  const [fatalError, setFatalError] = useState<Error | null>(null);
   const { showToast } = useToastStore();
   const methods = useForm({
     defaultValues: {
@@ -47,6 +48,10 @@ export default function SignupClient() {
     formState: { isSubmitting, errors, isDirty },
   } = methods;
 
+  if (fatalError) {
+    throw fatalError;
+  }
+
   /** 회원가입 요청 핸들러 */
   const handleSignup = useCallback(
     async (formData: SignupFormValues) => {
@@ -60,76 +65,79 @@ export default function SignupClient() {
         // 로그인 페이지로 이동
         router.push('/login');
       } catch (error) {
-        if (error instanceof ApiError) {
+        if (error instanceof NetworkError) {
+          showToast('cancel', '회원가입 중 오류가 발생했습니다.');
+          return;
+        }
+
+        if (error instanceof HttpError) {
+          if (error.status >= 500) {
+            setFatalError(error);
+            return;
+          }
+
           setError('root', {
             type: 'server',
             message: removeDotSuffix(error.message),
           });
-        } else {
-          // 네트워크 에러 등
-          showToast('cancel', '회원가입 중 오류가 발생했습니다.');
         }
+
+        showToast('cancel', '회원가입 중 오류가 발생했습니다.');
       }
     },
     [router, setError, showToast]
   );
 
   return (
-    <>
-      <div className="mt-17 md:mt-22">
-        <AuthForm onSubmit={handleSubmit(handleSignup)}>
-          <FormField label="이메일" errorMessage={errors.email?.message}>
-            <FormInput
-              type="email"
-              name="email"
-              control={control}
-              placeholder="이메일을 입력해 주세요"
-            />
-          </FormField>
+    <div className="mt-17 md:mt-22">
+      <AuthForm onSubmit={handleSubmit(handleSignup)}>
+        <FormField label="이메일" errorMessage={errors.email?.message}>
+          <FormInput
+            type="email"
+            name="email"
+            control={control}
+            placeholder="이메일을 입력해 주세요"
+          />
+        </FormField>
 
-          <FormField label="닉네임" errorMessage={errors.nickname?.message}>
-            <FormInput
-              type="text"
-              name="nickname"
-              control={control}
-              placeholder="닉네임을 입력해 주세요"
-            />
-          </FormField>
+        <FormField label="닉네임" errorMessage={errors.nickname?.message}>
+          <FormInput
+            type="text"
+            name="nickname"
+            control={control}
+            placeholder="닉네임을 입력해 주세요"
+          />
+        </FormField>
 
-          <FormField label="비밀번호" errorMessage={errors.password?.message}>
-            <PasswordInput
-              name="password"
-              control={control}
-              placeholder="비밀번호를 입력해 주세요"
-            />
-          </FormField>
+        <FormField label="비밀번호" errorMessage={errors.password?.message}>
+          <PasswordInput name="password" control={control} placeholder="비밀번호를 입력해 주세요" />
+        </FormField>
 
-          <FormField label="비밀번호 확인" errorMessage={errors.passwordConfirm?.message}>
-            <PasswordInput
-              name="passwordConfirm"
-              control={control}
-              placeholder="비밀번호를 한 번 더 입력해 주세요"
-            />
-          </FormField>
-          <div className="mt-1 md:mt-2">
-            {/* 백엔드 에러 메시지 */}
-            {errors.root && (
-              <FormErrorMessage className="typo-13-medium">{errors.root.message}</FormErrorMessage>
-            )}
-            <Button
-              type="submit"
-              theme="primary"
-              size="lg"
-              isLoading={isSubmitting}
-              disabled={!isDirty || isSubmitting}
-              className="mt-2 h-13.5 w-full rounded-2xl md:mt-2.5"
-            >
-              회원가입 하기
-            </Button>
-          </div>
-        </AuthForm>
-        <AuthFooter />
-      </div>
-    </>
+        <FormField label="비밀번호 확인" errorMessage={errors.passwordConfirm?.message}>
+          <PasswordInput
+            name="passwordConfirm"
+            control={control}
+            placeholder="비밀번호를 한 번 더 입력해 주세요"
+          />
+        </FormField>
+        <div className="mt-1 md:mt-2">
+          {/* 백엔드 에러 메시지 */}
+          {errors.root && (
+            <FormErrorMessage className="typo-13-medium">{errors.root.message}</FormErrorMessage>
+          )}
+          <Button
+            type="submit"
+            theme="primary"
+            size="lg"
+            isLoading={isSubmitting}
+            disabled={!isDirty || isSubmitting}
+            className="mt-2 h-13.5 w-full rounded-2xl md:mt-2.5"
+          >
+            회원가입 하기
+          </Button>
+        </div>
+      </AuthForm>
+      <AuthFooter />
+    </div>
   );
 }

--- a/src/features/auth/ui/SignupClient.tsx
+++ b/src/features/auth/ui/SignupClient.tsx
@@ -80,6 +80,7 @@ export default function SignupClient() {
             type: 'server',
             message: removeDotSuffix(error.message),
           });
+          return;
         }
 
         showToast('cancel', '회원가입 중 오류가 발생했습니다.');

--- a/src/features/my-page/activity-form/edit/hooks/useActivityEditSubmit.ts
+++ b/src/features/my-page/activity-form/edit/hooks/useActivityEditSubmit.ts
@@ -11,7 +11,7 @@ import { getImageUrl, getImageUrls } from '@/features/my-page/activity-form/comm
 import type { ActivityFormValues } from '@/features/my-page/activity-form/common/utils/schema';
 import { useUpdateActivity } from '@/features/my-page/activity-form/edit/mutations/useUpdateActivity';
 import type { ActivityDetailForForm } from '@/features/my-page/activity-form/types';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { QUERY_KEYS } from '@/shared/constants/queryKey';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
@@ -114,7 +114,7 @@ export const useActivityEditSubmit = (activityId: number, originalData?: Activit
       ]);
       router.push(`/activity/${activityId}`);
     } catch (error) {
-      if (error instanceof ApiError && error.status === HTTP_STATUS.BAD_REQUEST) {
+      if (error instanceof HttpError && error.status === HTTP_STATUS.BAD_REQUEST) {
         const errorMessage = error.message || ACTIVITY_ERROR_MESSAGES.SCHEDULE_CONFLICT;
 
         showToast('cancel', errorMessage);

--- a/src/features/my-page/common/ui/DeleteActivityDialog.tsx
+++ b/src/features/my-page/common/ui/DeleteActivityDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useDeleteActivity } from '@/features/my-page/common/mutations/useDeleteActivity';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import ConfirmDialog from '@/shared/ui/dialog/ConfirmDialog';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
@@ -35,7 +35,7 @@ export default function DeleteActivityDialog({ id, isOpen, onClose }: DeleteActi
           onClose();
           router.push('/mypage/activity');
         } catch (error) {
-          if (error instanceof ApiError) {
+          if (error instanceof HttpError) {
             if (error.status === 401) {
               showToast('cancel', '로그인이 필요합니다.');
               onClose();

--- a/src/features/reservation/activity-panel/hooks/useReservation.ts
+++ b/src/features/reservation/activity-panel/hooks/useReservation.ts
@@ -6,7 +6,7 @@ import type { ActivityDetail, ActivitySchedule } from '@/features/activity/types
 import { useCreateReservation } from '@/features/reservation/activity-panel/mutations/useCreateReservation';
 import { useAvailableSchedule } from '@/features/reservation/activity-panel/queries/useAvailableSchedule';
 import { useMyReservations } from '@/features/reservation/activity-panel/queries/useMyReservations';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { useUserStore } from '@/shared/stores/userStore';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
@@ -89,7 +89,7 @@ export const useReservation = (
           reset();
         },
         onError: (error: unknown) => {
-          if (error instanceof ApiError && error.status === 401) {
+          if (error instanceof HttpError && error.status === 401) {
             showToast('cancel', '로그인을 해주세요.');
             router.push('/login');
             return;

--- a/src/features/reservation/reservation-list/hooks/useReservationChange.ts
+++ b/src/features/reservation/reservation-list/hooks/useReservationChange.ts
@@ -6,7 +6,7 @@ import { useAvailableSchedule } from '@/features/reservation/activity-panel/quer
 import { useMyReservations } from '@/features/reservation/activity-panel/queries/useMyReservations';
 import { useUpdateMyReservationApplication } from '@/features/reservation/reservation-list/mutations/useUpdateMyReservationApplication';
 import type { MyReservation } from '@/features/reservation/types';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
 /**
@@ -81,7 +81,7 @@ export const useReservationChange = (reservation: MyReservation) => {
       showToast('check', '예약이 변경되었습니다.');
       return true;
     } catch (error: unknown) {
-      if (error instanceof ApiError && error.status === 401) {
+      if (error instanceof HttpError && error.status === 401) {
         showToast('cancel', '로그인을 해주세요.');
         return false;
       }

--- a/src/features/reservation/reservation-list/ui/CancelReservationDialog.tsx
+++ b/src/features/reservation/reservation-list/ui/CancelReservationDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useCancelMyReservation } from '@/features/reservation/reservation-list/mutations/useCancelMyReservation';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import ConfirmDialog from '@/shared/ui/dialog/ConfirmDialog';
 import { useToastStore } from '@/shared/ui/toast/stores/useToastStore';
 
@@ -36,7 +36,7 @@ export default function CancelReservationDialog({
             showToast('check', '예약이 취소되었습니다.');
           },
           onError: (error) => {
-            if (error instanceof ApiError) {
+            if (error instanceof HttpError) {
               if (error.status === 401) {
                 showToast('cancel', '로그인이 필요합니다.');
                 router.push('/login');

--- a/src/features/user/queries/userMeQueryOptions.ts
+++ b/src/features/user/queries/userMeQueryOptions.ts
@@ -1,6 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 import { getMe } from '@/features/user/apis';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { QUERY_KEYS } from '@/shared/constants/queryKey';
 
 const USER_ME_STALE_TIME_MS = 5 * 60_000;
@@ -15,7 +15,7 @@ export const userMeQueryOptions = () =>
     staleTime: USER_ME_STALE_TIME_MS,
     retry: (failureCount, error) => {
       if (failureCount >= 1) return false;
-      if (error instanceof ApiError) return error.status >= 500;
+      if (error instanceof HttpError) return error.status >= 500;
       return false;
     },
   });

--- a/src/shared/apis/apiError.ts
+++ b/src/shared/apis/apiError.ts
@@ -1,9 +1,16 @@
-export class ApiError extends Error {
+export class HttpError extends Error {
   status: number;
 
   constructor(status: number, message: string) {
     super(message);
     this.status = status;
-    this.name = 'ApiError';
+    this.name = 'HttpError';
+  }
+}
+
+export class NetworkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NetworkError';
   }
 }

--- a/src/shared/apis/base/bffFetch.refreshFallback.test.ts
+++ b/src/shared/apis/base/bffFetch.refreshFallback.test.ts
@@ -22,7 +22,7 @@ describe('bffFetch refresh-token fallback', () => {
   it('retries the original request once after a successful refresh', async () => {
     jest.resetModules();
     setupUserStoreMock();
-    const { ApiError } = await import('@/shared/apis/apiError');
+    const { HttpError } = await import('@/shared/apis/apiError');
 
     const urlCallCounts = new Map<string, number>();
     const coreFetchMock = jest.fn(async (url: string) => {
@@ -30,7 +30,7 @@ describe('bffFetch refresh-token fallback', () => {
 
       if (url === '/api/books?retry=1') {
         // 최초 요청은 401, refresh 성공 후 재시도는 성공
-        if (urlCallCounts.get(url) === 1) throw new ApiError(401, 'unauthorized');
+        if (urlCallCounts.get(url) === 1) throw new HttpError(401, 'unauthorized');
         return { ok: true };
       }
       if (url === '/api/auth/tokens') return { success: true, accessTokenExpiresAt: 123 };
@@ -69,11 +69,11 @@ describe('bffFetch refresh-token fallback', () => {
   it('clears the session as expired when refresh fails, then rethrows the original error', async () => {
     jest.resetModules();
     setupUserStoreMock();
-    const { ApiError } = await import('@/shared/apis/apiError');
+    const { HttpError } = await import('@/shared/apis/apiError');
 
     const coreFetchMock = jest.fn(async (url: string) => {
-      if (url === '/api/books') throw new ApiError(401, 'unauthorized');
-      if (url === '/api/auth/tokens') throw new ApiError(401, 'refresh failed');
+      if (url === '/api/books') throw new HttpError(401, 'unauthorized');
+      if (url === '/api/auth/tokens') throw new HttpError(401, 'refresh failed');
       return null;
     });
 
@@ -85,14 +85,14 @@ describe('bffFetch refresh-token fallback', () => {
 
     const { bffFetch } = await import('@/shared/apis/base/bffFetch');
 
-    await expect(bffFetch.get('/books')).rejects.toBeInstanceOf(ApiError);
+    await expect(bffFetch.get('/books')).rejects.toBeInstanceOf(HttpError);
     expect(mockClearSession).toHaveBeenCalledWith('expired');
   });
 
   it('deduplicates concurrent refresh calls (refresh only once)', async () => {
     jest.resetModules();
     setupUserStoreMock();
-    const { ApiError } = await import('@/shared/apis/apiError');
+    const { HttpError } = await import('@/shared/apis/apiError');
 
     let refreshCalls = 0;
     const urlCallCounts = new Map<string, number>();
@@ -107,7 +107,7 @@ describe('bffFetch refresh-token fallback', () => {
       }
       if (url === '/api/books?ok=1') {
         // 2개 요청이 각각 1번씩 401을 받고, refresh 이후에는 모두 성공해야 함
-        if ((urlCallCounts.get(url) ?? 0) <= 2) throw new ApiError(401, 'unauthorized');
+        if ((urlCallCounts.get(url) ?? 0) <= 2) throw new HttpError(401, 'unauthorized');
         return { ok: true };
       }
       return null;

--- a/src/shared/apis/base/bffFetch.ts
+++ b/src/shared/apis/base/bffFetch.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import {
   coreFetch,
   FetchRequestOptions,
@@ -97,7 +97,7 @@ const request = <T>({
       return await doRequest();
     } catch (error) {
       // 401이면(= access token 만료 가능성) refresh 후 상황에 따라 세션을 정리합니다.
-      if (error instanceof ApiError && error.status === 401 && !isAuthEndpoint(endpoint)) {
+      if (error instanceof HttpError && error.status === 401 && !isAuthEndpoint(endpoint)) {
         const refreshed = await refreshTokensOnce();
         if (!refreshed) {
           await clearSessionExpired();
@@ -107,7 +107,7 @@ const request = <T>({
         try {
           return await doRequest();
         } catch (retryError) {
-          if (retryError instanceof ApiError && retryError.status === 401) {
+          if (retryError instanceof HttpError && retryError.status === 401) {
             await clearSessionExpired();
           }
           throw retryError;

--- a/src/shared/apis/base/coreFetch.ts
+++ b/src/shared/apis/base/coreFetch.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError, NetworkError } from '@/shared/apis/apiError';
 import { COMMON_MESSAGE } from '@/shared/constants/message';
 
 /**
@@ -8,7 +8,7 @@ import { COMMON_MESSAGE } from '@/shared/constants/message';
  * - 요청 URL을 구성하고, 쿼리 파라미터를 추가할 수 있습니다.
  * - 요청 본문을 JSON 또는 FormData로 자동 변환합니다.
  * - 응답이 JSON인 경우 자동으로 파싱하여 반환합니다.
- * - 요청이 실패한 경우 ApiError를 던집니다.
+ * - 요청이 실패한 경우 HttpError 또는 NetworkError를 던집니다.
  * - 요청 타임아웃을 지원하여, 지정된 시간 내에 응답이 없으면 요청을 취소합니다.
  * - AbortSignal을 지원하여, 외부에서 요청을 취소할 수 있습니다.
  * @example
@@ -22,8 +22,10 @@ import { COMMON_MESSAGE } from '@/shared/constants/message';
  *     });
  *     console.log(data);
  *   } catch (error) {
- *     if (error instanceof ApiError) {
+ *     if (error instanceof HttpError) {
  *       console.error(`API Error: ${error.status} - ${error.message}`);
+ *     } else if (error instanceof NetworkError) {
+ *       console.error(`Network Error: ${error.message}`);
  *     } else {
  *       console.error('Unexpected Error:', error);
  *     }
@@ -124,7 +126,7 @@ export async function coreFetch<T>(
     const data = parseResponse(text, isJson);
 
     if (!res.ok) {
-      throw new ApiError(
+      throw new HttpError(
         res.status,
         data?.message || res.statusText || `API 요청 실패: ${res.status}`
       );
@@ -133,17 +135,17 @@ export async function coreFetch<T>(
     return data;
   } catch (error) {
     // Fetch 자체 실패(네트워크/타임아웃 abort 등)는 네트워크 에러 메세지로 통일
-    if (error instanceof ApiError) throw error;
+    if (error instanceof HttpError || error instanceof NetworkError) throw error;
 
     if (isAbortError(error)) {
       if (abortedByTimeout) {
-        throw new Error(COMMON_MESSAGE.ERROR.NETWORK);
+        throw new NetworkError(COMMON_MESSAGE.ERROR.NETWORK);
       }
       // 외부 취소(라우트 변경, 수동 abort 등)
       throw new Error('요청이 취소되었습니다.');
     }
 
-    throw new ApiError(500, COMMON_MESSAGE.ERROR.INTERNAL);
+    throw new NetworkError(COMMON_MESSAGE.ERROR.NETWORK);
   } finally {
     clearTimeout(timeoutId);
   }

--- a/src/shared/apis/bff/createAuthorizedRoute.ts
+++ b/src/shared/apis/bff/createAuthorizedRoute.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { ApiError } from '@/shared/apis/apiError';
+import { HttpError } from '@/shared/apis/apiError';
 import { COMMON_MESSAGE } from '@/shared/constants/message';
 
 /**
@@ -56,7 +56,7 @@ const parseRequestBody = async (request: Request): Promise<unknown> => {
     try {
       return JSON.parse(text) as unknown;
     } catch {
-      throw new ApiError(400, '요청 본문이 올바른 JSON 형식이 아닙니다.');
+      throw new HttpError(400, '요청 본문이 올바른 JSON 형식이 아닙니다.');
     }
   }
 
@@ -120,8 +120,8 @@ export const createAuthorizedRoute = <
 
       return NextResponse.json(result);
     } catch (error) {
-      if (error instanceof ApiError) {
-        return NextResponse.json({ message: error.message }, { status: error.status });
+      if (error instanceof HttpError) {
+        return NextResponse.json({ message: error.message }, { status: error.status ?? 500 });
       }
 
       return NextResponse.json({ message: COMMON_MESSAGE.ERROR.INTERNAL }, { status: 500 });


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #394

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 인증 에러 처리를 HttpError와 NetworkError로 분리해 HTTP 응답 에러와 네트워크 실패를 명확하게 구분했습니다.
- 로그인/회원가입에서 4xx는 기존처럼 폼 에러로 처리하고, 500대 서버 에러만 error.tsx로 이동하도록 정리했습니다.

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
